### PR TITLE
Simplify DB

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,11 +17,16 @@ datasource db {
 enum MembershipRole {
   ADMIN
   MEMBER
+  MANAGER
+  VIEWER
 }
 
 enum AccessLevel {
-  READ
-  EDIT
+  PUBLIC        // Anyone in org can read
+  GROUP         // All group members can read
+  MANAGERS      // Only managers+ can read
+  ADMINS        // Only admins can read
+  RESTRICTED    // Only specific users
 }
 
 model Organization {
@@ -31,6 +36,10 @@ model Organization {
   currentWordCount Int @default(0)
   lastIndexUpdate DateTime?
   lastDataChange DateTime @default(now())
+
+  defaultDocumentAccess AccessLevel @default(GROUP)
+  allowMemberUploads Boolean @default(true)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -38,9 +47,9 @@ model Organization {
   adminUser User @relation("AdminOrganizations", fields: [adminUserId], references: [id])
 
   memberships       OrganizationMembership[]
+  groups             Group[]
   documents         Document[]
   folders           Folder[]
-  permissionsGroups PermissionsGroup[]
   auditLogs         AuditLog[]
   searchQueries     SearchQuery[]
 
@@ -57,30 +66,26 @@ model User {
   updatedAt DateTime @updatedAt
 
   memberships        OrganizationMembership[]
+  groupMemberships   GroupMembership[]
   adminOrganizations Organization[] @relation("AdminOrganizations")
   auditLogs          AuditLog[]
   searchQueries      SearchQuery[]
   documentAccesses   DocumentAccess[]
-
-  // Access control relation
-  documentAccess   DocumentUserAccess[]
-
-  refreshTokens RefreshToken[]
+  refreshTokens      RefreshToken[]
 
   @@index([email])
 }
 
-model PermissionsGroup {
+model Group {
   id String @id @default(cuid())
-  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  organizationId String
   name String
   description String?
-  permissions String[] // Array of OrganizationPermission enum values
-  memberships OrganizationMembership[]
+  organizationId String
 
-  // Relations for access control
-  documentAccess   DocumentGroupAccess[]
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  members      GroupMembership[]
+  documents    Document[]
+  folders      Folder[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -89,18 +94,39 @@ model PermissionsGroup {
   @@index([organizationId])
 }
 
+model GroupMembership {
+  id String @id @default(cuid())
+  userId String
+  groupId String
+  role GroupRole @default(MEMBER)
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  group Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@unique([userId, groupId])
+  @@index([groupId])
+  @@index([userId])
+}
+
+enum GroupRole {
+  ADMIN
+  MEMBER
+}
+
 model OrganizationMembership {
   id     String   @id @default(cuid())
   userId String
+  organizationId String
   role   MembershipRole @default(MEMBER)
-  status MembershipStatus @default(PENDING)
+
+  canUpload Boolean @default(true)
+  canDelete Boolean @default(false)
+  canManageUsers Boolean @default(false)
 
   user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  organizationId String
-
-  permissionsGroup   PermissionsGroup? @relation(fields: [permissionsGroupId], references: [id])
-  permissionsGroupId String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -108,12 +134,6 @@ model OrganizationMembership {
   @@unique([userId, organizationId])
   @@index([organizationId])
   @@index([userId])
-}
-
-enum MembershipStatus {
-  PENDING
-  ACTIVE
-  REJECTED
 }
 
 model AuditLog {
@@ -140,8 +160,10 @@ model Folder {
   name          String
   isDeleted     Boolean @default(false)
   organizationId String
+  groupId String?
 
   organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  group Group?    @relation(fields: [groupId], references: [id], onDelete: SetNull)
   documents       Document[]
   parentFolder    Folder? @relation("FolderParent", fields: [parentFolderId], references: [id])
   parentFolderId  String?
@@ -151,6 +173,7 @@ model Folder {
   updatedAt DateTime @updatedAt
 
   @@index([organizationId])
+  @@index([groupId])
   @@index([parentFolderId])
 }
 
@@ -159,6 +182,15 @@ model Document {
   title         String
   isDeleted     Boolean @default(false)
   organizationId String
+  groupId       String?
+  folderId      String?
+
+  accessLevel AccessLevel @default(GROUP)
+  restrictedToUsers String[]? // If accessLevel == RESTRICTED, list of user IDs
+
+  organization  Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  group         Group? @relation(fields: [groupId], references: [id], onDelete: SetNull)
+  folder        Folder? @relation(fields: [folderId], references: [id], onDelete: SetNull)
 
   // S3 file storage
   s3Bucket      String?
@@ -166,14 +198,6 @@ model Document {
   originalFileName String?
   fileSize      Int?
   mimeType      String?
-
-  organization  Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  allowedGroups DocumentGroupAccess[]
-  allowedUsers  DocumentUserAccess[]
-  accesses      DocumentAccess[]
-
-  folder   Folder? @relation(fields: [folderId], references: [id], onDelete: SetNull)
-  folderId String?
 
   recency       Int @default(0)
   popularity    Int @default(0)
@@ -186,6 +210,7 @@ model Document {
   updatedAt DateTime @updatedAt
 
   @@index([organizationId])
+  @@index([groupId])
   @@index([folderId])
   @@index([isDeleted])
   @@index([recency])
@@ -239,59 +264,6 @@ model Embedding {
   @@index([isDeleted])
   @@index([recency])
   @@index([popularity])
-}
-
-// Join table for document-level group access
-model DocumentGroupAccess {
-  document    Document         @relation(fields: [documentId], references: [id], onDelete: Cascade)
-  documentId  String
-  group       PermissionsGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  groupId     String
-
-  accessLevel AccessLevel
-  grantedBy   String      // userId who granted access
-  grantedAt   DateTime    @default(now())
-
-  @@id([documentId, groupId])
-  @@index([documentId])
-  @@index([groupId])
-}
-
-// Join table for document-level user access
-model DocumentUserAccess {
-  document    Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
-  documentId  String
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId      String
-
-  accessLevel AccessLevel
-  grantedBy   String      // userId who granted access
-  grantedAt   DateTime    @default(now())
-
-  @@id([documentId, userId])
-  @@index([documentId])
-  @@index([userId])
-}
-
-
-// access tracking
-model DocumentAccess {
-  id String @id @default(cuid())
-
-  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId     String
-  document   Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
-  documentId String
-
-  accessCount    Int @default(1)
-  lastAccessedAt DateTime @default(now())
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
-
-  @@unique([userId, documentId])
-  @@index([userId])
-  @@index([documentId])
-  @@index([lastAccessedAt])
 }
 
 // Search analytics


### PR DESCRIPTION
This PR simplifies the design of the access control. Instead of allowing fine grained access control for every user down to the document level, we predefine member roles that can be assigned to the user when invited to the organization. However, I still want to enable the separation of documents inside the organization, so I added "groups", kinda like in workplace, where if you are in a group, you have access to all the documents that your role has access to in the group.

I also got rid of the document access log and the membership status, they weren't really necessary to have.
