### PR TITLE
Sessions

### DIFF
--- a/backend/src/services/sessionService.ts
+++ b/backend/src/services/sessionService.ts
@@ -1,0 +1,101 @@
+import { EventEmitter } from 'events';
+import { prisma } from '../lib/prisma';
+
+interface ActiveSession {
+  sessionId: string;
+  userId: string;
+  organizationId: string;
+  lastActivity: Date;
+  expiresAt: Date;
+}
+
+export class SessionService extends EventEmitter {
+	private activeSessions = new Map<string, ActiveSession>();
+	private organizationSessions = new Map<string, Set<string>>();
+	private sessionCleanupInterval: NodeJS.Timeout;
+
+	constructor() {
+		super();
+		this.sessionCleanupInterval = setInterval(() => {
+			this.cleanupExpiredSessions();
+		}, 1000 * 60 * 5); // every 5 minutes
+	}
+
+	async createSession(userId: string, organizationId: string): Promise<string> {
+		const sessionId = crypto.randomUUID();
+		const expiresAt = new Date(Date.now() + 8 * 60 * 60 * 1000); // 8 hours
+
+		const session: ActiveSession = {
+			sessionId,
+			userId,
+			organizationId,
+			lastActivity: new Date(),
+			expiresAt,
+		};
+
+		this.activeSessions.set(sessionId, session);
+
+		if (!this.organizationSessions.has(organizationId)) {
+			this.organizationSessions.set(organizationId, new Set());
+			// emit first active sesion from this org to start building search indices
+			this.emit('organizationFirstLogin', organizationId);
+		}
+
+		const orgSessions  = this.organizationSessions.get(organizationId);
+		if(orgSessions){
+			orgSessions.add(sessionId);
+		}
+
+		await prisma.session.create({
+			data: {
+				id: sessionId,
+				userId,
+				organizationId,
+				expiresAt,
+			}
+		});
+
+		return sessionId;
+	}
+
+	async destroySession(sessionId: string): Promise<void> {
+		const session = this.activeSessions.get(sessionId);
+		if (!session){
+			return;
+		}
+
+		const { organizationId } = session;
+
+		this.activeSessions.delete(sessionId);
+
+		const orgSessions = this.organizationSessions.get(organizationId);
+		if (orgSessions) {
+			orgSessions.delete(sessionId);
+
+			if (orgSessions.size === 0) {
+				this.organizationSessions.delete(organizationId);
+				this.emit('organizationLastLogout', organizationId);
+			}
+		}
+
+		await prisma.userSession.delete({
+			where: { id: sessionId }
+		})
+	}
+
+	private cleanupExpiredSessions(): void {
+		const now = new Date();
+		const expiredSessions: string[] = [];
+
+		for (const [sessionId, session] of this.activeSessions) {
+			if (session.expiresAt < now) {
+				expiredSessions.push(sessionId);
+			}
+		}
+
+		expiredSessions.forEach(sessionId => {
+			this.destroySession(sessionId);
+		})
+	}
+
+}


### PR DESCRIPTION
This PR is to create the session service. This project will be using both JWT and Sessions to manage user login. Original plan was to only use JWT, but since we now need to build and maintain the search indices in memory, sessions are necessary to track when their are active users in an organization. Having every search index for every organization running even when no one is logged in, would be wasting resources.

Maps of the current active sessions and active sessions in an organization are used to check when an organization first has a user login and when the last user for that organization logs out.