### PR TITLE
Use single instance of session service

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,9 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { AuthService } from '../services/authService';
-import { SessionService } from '../services/sessionService';
+import { sessionService } from '../services/sessionServiceSingleton';
 
-const sessionService = new SessionService();
- const authService = new AuthService(sessionService);
+const authService = new AuthService(sessionService);
 
  export class AuthController {
 
@@ -58,17 +57,26 @@ const sessionService = new SessionService();
         }
     }
 
-    // GET /api/auth/me
-    async getMe(req: Request, res: Response, next: NextFunction) {
-        try {
-            res.json({
-                user: req.user,
-                sessionActive: true,
-            });
-        } catch (error) {
-            next(error);
-        }
+  // GET /api/auth/me
+  async getMe(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userData = await authService.getUserWithOrganizations(
+        req.user!.userId
+      );
+
+      res.json({
+        user: {
+          id: userData.id,
+          name: userData.name,
+          email: userData.email,
+          organizations: userData.organizations,
+        },
+        sessionActive: true,
+      });
+    } catch (error) {
+      next(error);
     }
+  }
 
     // GET /api/auth/organizations
     async getUserOrganizations(req: Request, res: Response, next: NextFunction) {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,61 +1,101 @@
 import { Request, Response, NextFunction } from 'express';
 import { JWTUtils } from '../utils/jwt';
-import { AuthError } from '../utils/errors';
-import { PermissionError } from '../utils/errors';
-import { SessionService } from '../services/sessionService';
+import { sessionService } from '../services/sessionServiceSingleton';
+import { ERROR_CODES } from '../utils/errors';
 
-export const authenticateToken = (sessionService: SessionService) => {
-    return (req: Request, res: Response, next: NextFunction) => {
-        const authHeader = req.headers.authorization;
-        const token = authHeader && authHeader.split(' ')[1]; // bearer token
+export const authenticateToken = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const authHeader = req.headers.authorization;
 
-        if (!token) {
-            throw AuthError.tokenMissing();
-        }
+    const token = authHeader && authHeader.split(' ')[1]; // bearer token
 
-        try {
-            const payload = JWTUtils.verifyAccessToken(token);
-            const sessionInfo = sessionService.getSessionInfo(payload.sessionId);
+    if (!token) {
+      res.status(401).json({
+        error: {
+          code: ERROR_CODES.TOKEN_MISSING,
+          message: 'Authentication required. Please log in.',
+          name: 'TOKEN_MISSING',
+        },
+      });
+      return;
+    }
 
-            if (!sessionInfo) {
-                throw AuthError.tokenInvalid('Session expired');
-            }
+    const payload = JWTUtils.verifyAccessToken(token);
+    const sessionInfo = sessionService.getSessionInfo(payload.sessionId);
 
-            sessionService.updateSessionActivity(payload.sessionId);
-
-            req.user = payload;
-            next();
-        } catch (error) {
-            if (error instanceof AuthError) {
-                throw error;
-            }
-            throw AuthError.tokenInvalid();
-        }
-    };
+    sessionService.updateSessionActivity(payload.sessionId);
+    req.user = payload;
+    next();
+  } catch (error) {
+    res.status(401).json({
+      error: {
+        code: ERROR_CODES.TOKEN_INVALID,
+        message: 'Invalid authentication token. Please log in again.',
+        name: 'TOKEN_INVALID',
+      },
+    });
+    return;
+  }
 };
 
 export const requireRole = (roles: string[]) => {
-    return (req: Request, res: Response, next: NextFunction) => {
-        if (!req.user) {
-            throw AuthError.tokenMissing();
-        }
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      res.status(401).json({
+        error: {
+          code: ERROR_CODES.TOKEN_MISSING,
+          message: 'Authentication required. Please log in.',
+          name: 'TOKEN_MISSING',
+        },
+      });
+      return;
+    }
 
-        if (!roles.includes(req.user.role)) {
-            throw PermissionError.insufficientPermissions();
-        }
+    if (!roles.includes(req.user.role)) {
+      res.status(403).json({
+        error: {
+          code: ERROR_CODES.INSUFFICIENT_PERMISSIONS,
+          message: 'You do not have permission to perform this action.',
+          name: 'INSUFFICIENT_PERMISSIONS',
+        },
+      });
+      return;
+    }
 
         next();
     };
 };
 
-export const requireAdmin =  (req: Request, res: Response, next: NextFunction) => {
-    if (!req.user) {
-        throw AuthError.tokenMissing();
-    }
+export const requireAdmin = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (!req.user) {
+    res.status(401).json({
+      error: {
+        code: ERROR_CODES.TOKEN_MISSING,
+        message: 'Authentication required. Please log in.',
+        name: 'TOKEN_MISSING',
+      },
+    });
+    return;
+  }
 
-    if (!req.user.isAdmin) {
-        throw PermissionError.adminRequired();
-    }
+  if (!req.user.isAdmin) {
+    res.status(403).json({
+      error: {
+        code: ERROR_CODES.INSUFFICIENT_PERMISSIONS,
+        message: 'Administrator privileges required.',
+        name: 'ADMIN_REQUIRED',
+      },
+    });
+    return;
+  }
 
     next();
 };

--- a/backend/src/middleware/sessionActivity.ts
+++ b/backend/src/middleware/sessionActivity.ts
@@ -1,12 +1,14 @@
 import { Request, Response, NextFunction } from 'express';
-import { SessionService } from '../services/sessionService';
+import { sessionService } from '../services/sessionServiceSingleton';
 
-export const updateSessionActivity = (sessionService: SessionService) => {
-    return (req: Request, res: Response, next: NextFunction) => {
-        if (req.user?.sessionId) {
-            sessionService.updateSessionActivity(req.user.sessionId);
-        }
+export const updateSessionActivity = (
+  req: Request,
+  _res: Response,
+  next: NextFunction
+) => {
+  if (req.user?.sessionId) {
+    sessionService.updateSessionActivity(req.user.sessionId);
+  }
 
-        next();
-    };
+  next();
 };

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,8 +2,8 @@ import { Router } from "express";
 import { authController } from "../controllers/authController";
 import { authenticateToken, requireAdmin } from "../middleware/auth";
 
-const createAuthRoutes = (sessionService: any) => {
-    const router = Router();
+const createAuthRoutes = () => {
+  const router = Router();
 
     router.post('/register', authController.register);
     router.post('/login', authController.login);
@@ -11,8 +11,13 @@ const createAuthRoutes = (sessionService: any) => {
     router.post('/logout', authController.logout);
     router.get('/organizations', authController.getUserOrganizations);
 
-    router.post('/logout-all', authenticateToken(sessionService), requireAdmin, authController.logoutAll);
-    router.get('/me', authenticateToken(sessionService), authController.getMe);
+  router.post(
+    '/logout-all',
+    authenticateToken,
+    requireAdmin,
+    authController.logoutAll
+  );
+  router.get('/me', authenticateToken, authController.getMe);
 
     return router;
 };

--- a/backend/src/services/sessionServiceSingleton.ts
+++ b/backend/src/services/sessionServiceSingleton.ts
@@ -1,0 +1,2 @@
+import { SessionService } from './sessionService';
+export const sessionService = new SessionService();


### PR DESCRIPTION
There was an error checking if a session exists for a logged in user because multiple instances of the session service were being created and therefore, there were different versions of the active sessions map. To fix this I created a singleton instance of the session service and imported it into all files that use it instead of them creating new instances or being passed as a parameter.

There are also some code quality improvements and additional error fixes in this PR