### PR TITLE
Chat page

### DIFF
--- a/frontend/src/components/chat/ChatArea.tsx
+++ b/frontend/src/components/chat/ChatArea.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { ChatMessages } from './ChatMessages';
+import { ChatInput } from './ChatInput';
+import { DocumentContextModal } from './DocumentContextModal';
+import { useChat } from '../../hooks/chat';
+
+interface ChatAreaProps {
+  // TODO: Add props when integrating with API
+}
+
+export const ChatArea: React.FC<ChatAreaProps> = () => {
+  const {
+    messages,
+    selectedContext,
+    isContextModalOpen,
+    isLoading,
+    handleSendMessage,
+    handleOpenContextModal,
+    handleCloseContextModal,
+    handleSelectContext,
+  } = useChat();
+
+  return (
+    <div className="flex-1 flex flex-col">
+      <ChatMessages messages={messages} />
+
+      <ChatInput
+        onSendMessage={handleSendMessage}
+        onOpenContextModal={handleOpenContextModal}
+        selectedContext={selectedContext}
+        isLoading={isLoading}
+      />
+
+      {isContextModalOpen && (
+        <DocumentContextModal
+          isOpen={isContextModalOpen}
+          onClose={handleCloseContextModal}
+          onSelectContext={handleSelectContext}
+          selectedContext={selectedContext}
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useMessageInput } from '../../hooks/chat';
+import { ContextDisplay } from './ContextDisplay';
+import { MessageInput } from './MessageInput';
+import { chatStyles } from '../../styles/chatStyles';
+
+interface ChatInputProps {
+  onSendMessage: (message: string, selectedContext?: string[]) => void;
+  onOpenContextModal: () => void;
+  selectedContext: string[];
+  isLoading?: boolean;
+}
+
+const InputHints: React.FC = () => (
+  <div className={chatStyles.messageInput.hints}>
+    Press Enter to send, Shift+Enter for new line
+  </div>
+);
+
+export const ChatInput: React.FC<ChatInputProps> = ({
+  onSendMessage,
+  onOpenContextModal,
+  selectedContext,
+  isLoading = false,
+}) => {
+  const {
+    message,
+    textareaRef,
+    handleInputChange,
+    handleKeyDown,
+    handleSubmit,
+  } = useMessageInput({
+    onSendMessage,
+    selectedContext,
+    isLoading,
+  });
+
+  const handleRemoveContext = (contextId: string) => {
+    // TODO: Implement context removal
+  };
+
+  return (
+    <div className={chatStyles.chatInput.container.base} style={chatStyles.chatInput.container.style}>
+      <ContextDisplay
+        selectedContext={selectedContext}
+        onRemoveContext={handleRemoveContext}
+      />
+
+      <form onSubmit={handleSubmit}>
+        <MessageInput
+          value={message}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          textareaRef={textareaRef}
+          isLoading={isLoading}
+          onOpenContextModal={onOpenContextModal}
+        />
+      </form>
+
+      <InputHints />
+    </div>
+  );
+};

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { TYPOGRAPHY_STYLES } from '../../styles/typographyStyles';
+import { Message } from '../../types';
+import { useSourceExpansion } from '../../hooks/chat';
+import { MessageContainer } from './MessageContainer';
+
+interface ChatMessagesProps {
+  messages: Message[];
+}
+
+const EmptyState: React.FC = () => (
+  <div className="flex-1 flex items-center justify-center">
+    <div className="text-center">
+      <div className="text-6xl mb-4">💬</div>
+      <h3 className={TYPOGRAPHY_STYLES.headings.h3}>
+        Start a conversation
+      </h3>
+      <p className={`${TYPOGRAPHY_STYLES.secondary.base} mt-2`}>
+        Ask questions about your documents and I'll help you find the answers.
+      </p>
+    </div>
+  </div>
+);
+
+export const ChatMessages: React.FC<ChatMessagesProps> = ({ messages }) => {
+  const { expandedSources, toggleSourceExpansion } = useSourceExpansion();
+
+  if (messages.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      {messages.map((message) => (
+        <MessageContainer
+          key={message.id}
+          message={message}
+          expandedSources={expandedSources}
+          onToggleSource={toggleSourceExpansion}
+        />
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/components/chat/ContextDisplay.tsx
+++ b/frontend/src/components/chat/ContextDisplay.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { chatStyles } from '../../styles/chatStyles';
+
+interface ContextDisplayProps {
+  selectedContext: string[];
+  onRemoveContext: (contextId: string) => void;
+}
+
+const ContextBadge: React.FC<{
+  contextId: string;
+  onRemove: () => void;
+}> = ({ contextId, onRemove }) => (
+  <span
+    className={chatStyles.contextDisplay.badge.base}
+    style={chatStyles.contextDisplay.badge.getStyle()}
+  >
+    📄 {contextId}
+    <button
+      onClick={onRemove}
+      className={chatStyles.contextDisplay.removeButton}
+      title="Remove context"
+    >
+      ×
+    </button>
+  </span>
+);
+
+export const ContextDisplay: React.FC<ContextDisplayProps> = ({
+  selectedContext,
+  onRemoveContext
+}) => {
+  if (selectedContext.length === 0) return null;
+
+  return (
+    <div className={chatStyles.contextDisplay.container}>
+      <span className={chatStyles.contextDisplay.label}>
+        Context:
+      </span>
+      {selectedContext.map((contextId) => (
+        <ContextBadge
+          key={contextId}
+          contextId={contextId}
+          onRemove={() => onRemoveContext(contextId)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/components/chat/DocumentContextModal.tsx
+++ b/frontend/src/components/chat/DocumentContextModal.tsx
@@ -1,0 +1,322 @@
+import React, { useState } from 'react';
+import { COLORS } from '../../styles/colors';
+import { TYPOGRAPHY_STYLES } from '../../styles/typographyStyles';
+import { BUTTON_BASE_CLASSES, BUTTON_VARIANTS } from '../../styles/buttonStyles';
+import { INPUT_BASE_CLASSES, INPUT_STATES } from '../../styles/inputStyles';
+import { Document } from '../../types';
+
+interface DocumentContextModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectContext: (selectedIds: string[]) => void;
+  selectedContext: string[];
+}
+
+// Mock data - TODO: Replace with API service
+const mockDocuments: Document[] = [
+  {
+    id: 'doc-1',
+    title: 'Building A - Lease Agreement',
+    type: 'document',
+    groupId: 'group-1',
+    accessLevel: 'GROUP',
+    size: '2.3 MB',
+  },
+  {
+    id: 'doc-2',
+    title: 'Safety Protocols Manual',
+    type: 'document',
+    groupId: 'group-2',
+    accessLevel: 'PUBLIC',
+    size: '1.8 MB',
+  },
+  {
+    id: 'doc-3',
+    title: 'Equipment Maintenance Guide',
+    type: 'document',
+    groupId: 'group-2',
+    accessLevel: 'GROUP',
+    size: '956 KB',
+  },
+  {
+    id: 'folder-1',
+    title: 'Property Management',
+    type: 'folder',
+    groupId: 'group-1',
+    accessLevel: 'GROUP',
+    children: [
+      {
+        id: 'doc-4',
+        title: 'Building B - Service Contract',
+        type: 'document',
+        groupId: 'group-1',
+        accessLevel: 'GROUP',
+        size: '1.2 MB',
+      },
+      {
+        id: 'doc-5',
+        title: 'Maintenance Schedule 2024',
+        type: 'document',
+        groupId: 'group-1',
+        accessLevel: 'MANAGERS',
+        size: '456 KB',
+      },
+    ],
+  },
+  {
+    id: 'folder-2',
+    title: 'Janitorial Procedures',
+    type: 'folder',
+    groupId: 'group-2',
+    accessLevel: 'GROUP',
+    children: [
+      {
+        id: 'doc-6',
+        title: 'Daily Cleaning Checklist',
+        type: 'document',
+        groupId: 'group-2',
+        accessLevel: 'PUBLIC',
+        size: '123 KB',
+      },
+      {
+        id: 'doc-7',
+        title: 'Chemical Safety Data Sheets',
+        type: 'document',
+        groupId: 'group-2',
+        accessLevel: 'GROUP',
+        size: '3.1 MB',
+      },
+    ],
+  },
+];
+
+const styles = {
+  modal: {
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  content: {
+    backgroundColor: COLORS.oatMilk,
+    borderColor: COLORS.lavender,
+  },
+  documentItem: {
+    backgroundColor: 'white',
+    borderColor: COLORS.lavender,
+  },
+  checkbox: {
+    accentColor: COLORS.forestGreen,
+  },
+};
+
+const DocumentItem: React.FC<{
+  document: Document;
+  isSelected: boolean;
+  onToggle: (id: string) => void;
+}> = ({ document, isSelected, onToggle }) => (
+  <div
+    className="p-3 rounded-lg border transition-all hover:shadow-sm"
+    style={styles.documentItem}
+  >
+    <label className="flex items-center gap-3 cursor-pointer">
+      <input
+        type="checkbox"
+        checked={isSelected}
+        onChange={() => onToggle(document.id)}
+        className="w-4 h-4"
+        style={styles.checkbox}
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span>{document.type === 'document' ? '📄' : '📁'}</span>
+          <span className={`${TYPOGRAPHY_STYLES.body.base} font-medium truncate`}>
+            {document.title}
+          </span>
+        </div>
+        {document.size && (
+          <div className={`${TYPOGRAPHY_STYLES.secondary.small} mt-1`}>
+            {document.size}
+          </div>
+        )}
+      </div>
+    </label>
+
+    {document.children && (
+      <div className="ml-6 mt-2 space-y-2">
+        {document.children.map((child) => (
+          <DocumentItem
+            key={child.id}
+            document={child}
+            isSelected={isSelected}
+            onToggle={onToggle}
+          />
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+const SearchInput: React.FC<{
+  value: string;
+  onChange: (value: string) => void;
+}> = ({ value, onChange }) => (
+  <div className="relative">
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="Search documents and folders..."
+      className={`w-full ${INPUT_BASE_CLASSES} ${INPUT_STATES.default} pl-10`}
+    />
+    <div className="absolute left-3 top-1/2 transform -translate-y-1/2">
+      🔍
+    </div>
+  </div>
+);
+
+const SelectAllToggle: React.FC<{
+  allSelected: boolean;
+  onToggle: () => void;
+}> = ({ allSelected, onToggle }) => (
+  <button
+    onClick={onToggle}
+    className={`${TYPOGRAPHY_STYLES.body.base} font-medium transition-colors hover:opacity-75`}
+    style={{ color: COLORS.forestGreen }}
+  >
+    {allSelected ? 'Deselect All' : 'Select All'}
+  </button>
+);
+
+const ActionButtons: React.FC<{
+  onCancel: () => void;
+  onApply: () => void;
+  selectedCount: number;
+}> = ({ onCancel, onApply, selectedCount }) => (
+  <div className="flex justify-between items-center">
+    <span className={TYPOGRAPHY_STYLES.secondary.base}>
+      {selectedCount} item{selectedCount !== 1 ? 's' : ''} selected
+    </span>
+    <div className="flex gap-3">
+      <button
+        onClick={onCancel}
+        className={`${BUTTON_BASE_CLASSES} ${BUTTON_VARIANTS.secondary}`}
+      >
+        Cancel
+      </button>
+      <button
+        onClick={onApply}
+        className={`${BUTTON_BASE_CLASSES} ${BUTTON_VARIANTS.primary}`}
+      >
+        Apply Context
+      </button>
+    </div>
+  </div>
+);
+
+export const DocumentContextModal: React.FC<DocumentContextModalProps> = ({
+  isOpen,
+  onClose,
+  onSelectContext,
+  selectedContext,
+}) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [localSelectedIds, setLocalSelectedIds] = useState<Set<string>>(
+    new Set(selectedContext)
+  );
+
+  if (!isOpen) return null;
+
+  const filteredDocuments = mockDocuments.filter((doc) =>
+    doc.title.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const allDocumentIds = mockDocuments.flatMap((doc) => {
+    if (doc.children) {
+      return [doc.id, ...doc.children.map((child) => child.id)];
+    }
+    return [doc.id];
+  });
+
+  const allSelected = allDocumentIds.every((id) => localSelectedIds.has(id));
+
+  const handleToggleDocument = (id: string) => {
+    const newSelected = new Set(localSelectedIds);
+    if (newSelected.has(id)) {
+      newSelected.delete(id);
+    } else {
+      newSelected.add(id);
+    }
+    setLocalSelectedIds(newSelected);
+  };
+
+  const handleSelectAll = () => {
+    if (allSelected) {
+      setLocalSelectedIds(new Set());
+    } else {
+      setLocalSelectedIds(new Set(allDocumentIds));
+    }
+  };
+
+  const handleApply = () => {
+    onSelectContext(Array.from(localSelectedIds));
+  };
+
+  const handleCancel = () => {
+    setLocalSelectedIds(new Set(selectedContext));
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={styles.modal}
+    >
+      <div
+        className="w-full max-w-2xl max-h-[80vh] rounded-xl border shadow-xl flex flex-col"
+        style={styles.content}
+      >
+        <div className="p-6 border-b" style={{ borderColor: COLORS.lavender }}>
+          <h2 className={TYPOGRAPHY_STYLES.headings.h2}>
+            Select Document Context
+          </h2>
+          <p className={`${TYPOGRAPHY_STYLES.secondary.base} mt-2`}>
+            Choose documents and folders to provide context for your question.
+          </p>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <SearchInput value={searchTerm} onChange={setSearchTerm} />
+
+          <div className="flex justify-between items-center">
+            <span className={`${TYPOGRAPHY_STYLES.body.base} font-medium`}>
+              Available Documents
+            </span>
+            <SelectAllToggle
+              allSelected={allSelected}
+              onToggle={handleSelectAll}
+            />
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 pb-4">
+          <div className="space-y-3">
+            {filteredDocuments.map((document) => (
+              <DocumentItem
+                key={document.id}
+                document={document}
+                isSelected={localSelectedIds.has(document.id)}
+                onToggle={handleToggleDocument}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="p-6 border-t" style={{ borderColor: COLORS.lavender }}>
+          <ActionButtons
+            onCancel={handleCancel}
+            onApply={handleApply}
+            selectedCount={localSelectedIds.size}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}; 

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { TYPOGRAPHY_STYLES } from '../../styles/typographyStyles';
+import { Message } from '../../types';
+import { chatStyles, combineStyles, getConditionalStyle } from '../../styles/chatStyles';
+
+interface MessageBubbleProps {
+  message: Message;
+  isUser: boolean;
+}
+
+export const MessageBubble: React.FC<MessageBubbleProps> = ({ message, isUser }) => (
+  <div
+    className={combineStyles(
+      chatStyles.messageBubble.base,
+      getConditionalStyle(isUser, chatStyles.messageBubble.userVariant, chatStyles.messageBubble.assistantVariant)
+    )}
+    style={chatStyles.messageBubble.getThemeStyle(isUser)}
+  >
+    <p className={TYPOGRAPHY_STYLES.body.base}>
+      {message.content}
+    </p>
+  </div>
+);

--- a/frontend/src/components/chat/SourcesSection.tsx
+++ b/frontend/src/components/chat/SourcesSection.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Message, Source } from '../../types';
+import { chatStyles } from '../../styles/chatStyles';
+
+interface SourcesSectionProps {
+  message: Message;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+const SourceItem: React.FC<{ source: Source }> = ({ source }) => (
+  <div
+    className={chatStyles.sourcesSection.sourceItem.base}
+    style={chatStyles.sourcesSection.sourceItem.getStyle()}
+  >
+    <div className={chatStyles.sourcesSection.sourceHeader}>
+      <span>{source.type === 'document' ? '📄' : '📁'}</span>
+      <span className={chatStyles.sourcesSection.sourceTitle}>
+        {source.title}
+      </span>
+    </div>
+    {source.excerpt && (
+      <p className={chatStyles.sourcesSection.sourceExcerpt}>
+        "{source.excerpt}"
+      </p>
+    )}
+  </div>
+);
+
+export const SourcesSection: React.FC<SourcesSectionProps> = ({ message, isExpanded, onToggle }) => {
+  if (!message.sources || message.sources.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={chatStyles.sourcesSection.container}>
+      <button
+        onClick={onToggle}
+        className={chatStyles.sourcesSection.toggleButton}
+      >
+        <span>📚</span>
+        Sources ({message.sources.length})
+        <span className="text-xs">
+          {isExpanded ? '▼' : '▶'}
+        </span>
+      </button>
+
+      {isExpanded && (
+        <div className={chatStyles.sourcesSection.expandedContainer}>
+          {message.sources.map((source) => (
+            <SourceItem key={source.id} source={source} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/chat/index.ts
+++ b/frontend/src/hooks/chat/index.ts
@@ -1,0 +1,6 @@
+export { useChat } from './useChat';
+export { useMessageInput } from './useMessageInput';
+export { useSourceExpansion } from './useSourceExpansion';
+export type { UseChatReturn } from './useChat';
+export type { UseMessageInputReturn, UseMessageInputOptions } from './useMessageInput';
+export type { UseSourceExpansionReturn } from './useSourceExpansion';

--- a/frontend/src/hooks/chat/useChat.ts
+++ b/frontend/src/hooks/chat/useChat.ts
@@ -1,0 +1,104 @@
+import { useState, useCallback, useEffect } from 'react';
+import { Message } from '../../types';
+import { chatService } from '../../services/chatService';
+
+export interface UseChatReturn {
+  messages: Message[];
+  selectedContext: string[];
+  isContextModalOpen: boolean;
+  isLoading: boolean;
+  error: string | null;
+  handleSendMessage: (content: string, contextIds?: string[]) => Promise<void>;
+  handleOpenContextModal: () => void;
+  handleCloseContextModal: () => void;
+  handleSelectContext: (contextIds: string[]) => void;
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
+  clearError: () => void;
+}
+
+export const useChat = (): UseChatReturn => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [selectedContext, setSelectedContext] = useState<string[]>([]);
+  const [isContextModalOpen, setIsContextModalOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load initial messages
+  useEffect(() => {
+    const loadMessages = async () => {
+      try {
+        const initialMessages = await chatService.getMessages();
+        setMessages(initialMessages);
+      } catch (err) {
+        console.error('Error loading messages:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load messages');
+      }
+    };
+
+    loadMessages();
+  }, []);
+
+  const handleSendMessage = useCallback(async (content: string, contextIds?: string[]) => {
+    const userMessage: Message = {
+      id: `msg-${Date.now()}`,
+      type: 'user',
+      content,
+      timestamp: new Date(),
+    };
+
+    setMessages(prev => [...prev, userMessage]);
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const aiMessage = await chatService.sendMessage({
+        content,
+        contextIds,
+        // TODO: Add organizationId when available
+        // organizationId: currentOrganization.id
+      });
+
+      setMessages(prev => [...prev, aiMessage]);
+    } catch (err) {
+      console.error('Error sending message:', err);
+      const errorMessage = err instanceof Error ? err.message : 'Failed to send message';
+      setError(errorMessage);
+
+      // Remove the user message if sending failed
+      setMessages(prev => prev.filter(msg => msg.id !== userMessage.id));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const handleOpenContextModal = useCallback(() => {
+    setIsContextModalOpen(true);
+  }, []);
+
+  const handleCloseContextModal = useCallback(() => {
+    setIsContextModalOpen(false);
+  }, []);
+
+  const handleSelectContext = useCallback((contextIds: string[]) => {
+    setSelectedContext(contextIds);
+    setIsContextModalOpen(false);
+  }, []);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return {
+    messages,
+    selectedContext,
+    isContextModalOpen,
+    isLoading,
+    error,
+    handleSendMessage,
+    handleOpenContextModal,
+    handleCloseContextModal,
+    handleSelectContext,
+    setMessages,
+    clearError,
+  };
+};

--- a/frontend/src/hooks/chat/useMessageInput.ts
+++ b/frontend/src/hooks/chat/useMessageInput.ts
@@ -1,0 +1,73 @@
+import { useState, useRef, useCallback } from 'react';
+
+export interface UseMessageInputReturn {
+  message: string;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  handleInputChange: (value: string) => void;
+  handleKeyDown: (e: React.KeyboardEvent) => void;
+  handleSubmit: (e: React.FormEvent) => void;
+  resetInput: () => void;
+}
+
+export interface UseMessageInputOptions {
+  onSendMessage: (message: string, selectedContext?: string[]) => void;
+  selectedContext: string[];
+  isLoading: boolean;
+}
+
+export const useMessageInput = ({
+  onSendMessage,
+  selectedContext,
+  isLoading,
+}: UseMessageInputOptions): UseMessageInputReturn => {
+  const [message, setMessage] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSubmit = useCallback((e: React.FormEvent) => {
+    e.preventDefault();
+    if (message.trim() && !isLoading) {
+      onSendMessage(
+        message.trim(),
+        selectedContext.length > 0 ? selectedContext : undefined
+      );
+      setMessage('');
+      // Reset textarea height
+      if (textareaRef.current) {
+        textareaRef.current.style.height = 'auto';
+      }
+    }
+  }, [message, isLoading, onSendMessage, selectedContext]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  }, [handleSubmit]);
+
+  const handleInputChange = useCallback((value: string) => {
+    setMessage(value);
+
+    // Auto-resize textarea
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 120)}px`;
+    }
+  }, []);
+
+  const resetInput = useCallback(() => {
+    setMessage('');
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+  }, []);
+
+  return {
+    message,
+    textareaRef,
+    handleInputChange,
+    handleKeyDown,
+    handleSubmit,
+    resetInput,
+  };
+};

--- a/frontend/src/hooks/chat/useSourceExpansion.ts
+++ b/frontend/src/hooks/chat/useSourceExpansion.ts
@@ -1,0 +1,55 @@
+import { useState, useCallback } from 'react';
+
+export interface UseSourceExpansionReturn {
+  expandedSources: Set<string>;
+  toggleSourceExpansion: (messageId: string) => void;
+  isSourceExpanded: (messageId: string) => boolean;
+  expandSource: (messageId: string) => void;
+  collapseSource: (messageId: string) => void;
+  collapseAllSources: () => void;
+}
+
+export const useSourceExpansion = (): UseSourceExpansionReturn => {
+  const [expandedSources, setExpandedSources] = useState<Set<string>>(new Set());
+
+  const toggleSourceExpansion = useCallback((messageId: string) => {
+    setExpandedSources(prev => {
+      const newExpanded = new Set(prev);
+      if (newExpanded.has(messageId)) {
+        newExpanded.delete(messageId);
+      } else {
+        newExpanded.add(messageId);
+      }
+      return newExpanded;
+    });
+  }, []);
+
+  const isSourceExpanded = useCallback((messageId: string) => {
+    return expandedSources.has(messageId);
+  }, [expandedSources]);
+
+  const expandSource = useCallback((messageId: string) => {
+    setExpandedSources(prev => new Set(prev).add(messageId));
+  }, []);
+
+  const collapseSource = useCallback((messageId: string) => {
+    setExpandedSources(prev => {
+      const newExpanded = new Set(prev);
+      newExpanded.delete(messageId);
+      return newExpanded;
+    });
+  }, []);
+
+  const collapseAllSources = useCallback(() => {
+    setExpandedSources(new Set());
+  }, []);
+
+  return {
+    expandedSources,
+    toggleSourceExpansion,
+    isSourceExpanded,
+    expandSource,
+    collapseSource,
+    collapseAllSources,
+  };
+};

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -1,0 +1,234 @@
+import { ApiError } from './api';
+import { Message } from '../types';
+
+export interface SendMessageRequest {
+  content: string;
+  contextIds?: string[];
+  organizationId?: string;
+}
+
+export interface SendMessageResponse {
+  message: Message;
+}
+
+export interface GetMessagesResponse {
+  messages: Message[];
+}
+
+export interface ChatHistoryItem {
+  id: string;
+  title: string;
+  timestamp: string;
+  preview: string;
+}
+
+export interface GetChatHistoryResponse {
+  chats: ChatHistoryItem[];
+}
+
+// TODO: Remove when real API is implemented
+const mockMessages: Message[] = [
+  {
+    id: 'msg-1',
+    type: 'user',
+    content: 'What are the safety protocols for building maintenance?',
+    timestamp: new Date('2024-01-15T10:30:00'),
+  },
+  {
+    id: 'msg-2',
+    type: 'assistant',
+    content: 'Based on the safety manual and building maintenance protocols, here are the key safety requirements for building maintenance:\n\n1. **Personal Protective Equipment (PPE)**\n   - Hard hats must be worn in all construction areas\n   - Safety goggles required when using power tools\n   - Non-slip footwear mandatory\n\n2. **Electrical Safety**\n   - Always turn off power at the breaker before electrical work\n   - Use lockout/tagout procedures\n   - Test circuits before beginning work\n\n3. **Fall Protection**\n   - Safety harnesses required for work above 6 feet\n   - Inspect ladders before each use\n   - Maintain 3-point contact when climbing',
+    timestamp: new Date('2024-01-15T10:30:30'),
+    sources: [
+      {
+        id: 'source-1',
+        title: 'Building Safety Manual.pdf',
+        type: 'document',
+        excerpt: 'Personal protective equipment must be worn at all times during maintenance operations...'
+      },
+      {
+        id: 'source-2',
+        title: 'Electrical Safety Protocols.pdf',
+        type: 'document',
+        excerpt: 'Lockout/tagout procedures are mandatory for all electrical maintenance work...'
+      }
+    ]
+  },
+  {
+    id: 'msg-3',
+    type: 'user',
+    content: 'How often should fire extinguishers be inspected?',
+    timestamp: new Date('2024-01-15T10:35:00'),
+  }
+];
+
+const mockChatHistory: ChatHistoryItem[] = [
+  {
+    id: 'chat-1',
+    title: 'Building Safety Protocols',
+    timestamp: '2024-01-15T10:30:00',
+    preview: 'What are the safety protocols for building maintenance?'
+  },
+  {
+    id: 'chat-2',
+    title: 'Fire Safety Guidelines',
+    timestamp: '2024-01-14T14:20:00',
+    preview: 'Can you explain the fire evacuation procedures?'
+  },
+  {
+    id: 'chat-3',
+    title: 'Maintenance Schedule',
+    timestamp: '2024-01-13T09:15:00',
+    preview: 'What is the regular maintenance schedule for HVAC systems?'
+  }
+];
+
+class ChatService {
+  async sendMessage(request: SendMessageRequest): Promise<Message> {
+    try {
+      // TODO: Replace with actual API call
+      // const response = await apiClient.post<SendMessageResponse>('/api/chat/messages', request);
+      // return response.message;
+
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          const aiMessage: Message = {
+            id: `msg-${Date.now()}`,
+            type: 'assistant',
+            content: 'I understand your question. Let me search through the relevant documents to provide you with an accurate answer.',
+            timestamp: new Date(),
+            sources: request.contextIds ? [
+              {
+                id: 'context-source-1',
+                title: 'Selected Document.pdf',
+                type: 'document',
+                excerpt: 'Relevant excerpt from the selected context...'
+              }
+            ] : undefined
+          };
+          resolve(aiMessage);
+        }, 1500);
+      });
+
+    } catch (error) {
+      throw this.handleChatError(error);
+    }
+  }
+
+  async getMessages(): Promise<Message[]> {
+    try {
+      // TODO: Replace with actual API call
+      // const response = await apiClient.get<GetMessagesResponse>('/api/chat/messages');
+      // return response.messages;
+
+      return Promise.resolve(mockMessages);
+
+    } catch (error) {
+      throw this.handleChatError(error);
+    }
+  }
+
+  async getChatHistory(): Promise<ChatHistoryItem[]> {
+    try {
+      // TODO: Replace with actual API call
+      // const response = await apiClient.get<GetChatHistoryResponse>('/api/chat/history');
+      // return response.chats;
+
+      return Promise.resolve(mockChatHistory);
+
+    } catch (error) {
+      throw this.handleChatError(error);
+    }
+  }
+
+  async createNewChat(): Promise<{ chatId: string }> {
+    try {
+      // TODO: Replace with actual API call
+      // const response = await apiClient.post<{ chatId: string }>('/api/chat/new');
+      // return response;
+
+      return Promise.resolve({ chatId: `chat-${Date.now()}` });
+
+    } catch (error) {
+      throw this.handleChatError(error);
+    }
+  }
+
+  async deleteChat(): Promise<void> {
+    try {
+      // TODO: Replace with actual API call
+      // await apiClient.delete('/api/chat/current');
+
+      return Promise.resolve();
+
+    } catch (error) {
+      throw this.handleChatError(error);
+    }
+  }
+
+  async updateChatTitle(): Promise<void> {
+    try {
+      // TODO: Replace with actual API call
+      // await apiClient.put('/api/chat/current/title', { title });
+
+      return Promise.resolve();
+
+    } catch (error) {
+      throw this.handleChatError(error);
+    }
+  }
+
+  private handleChatError(error: unknown): Error {
+    if (error instanceof ApiError) {
+      // Handle chat-specific error codes
+      if (error.code) {
+        switch (error.code) {
+          case '2001': // CHAT_NOT_FOUND
+            return new Error('Chat conversation not found.');
+          case '2002': // MESSAGE_TOO_LONG
+            return new Error('Message is too long. Please shorten your message and try again.');
+          case '2003': // CONTEXT_LIMIT_EXCEEDED
+            return new Error('Too many documents selected. Please reduce the number of context documents.');
+          case '2004': // RATE_LIMIT_EXCEEDED
+            return new Error('Too many messages sent. Please wait a moment before sending another message.');
+          case '2005': // DOCUMENT_NOT_ACCESSIBLE
+            return new Error('One or more selected documents are not accessible.');
+          case '2006': // PROCESSING_ERROR
+            return new Error('Error processing your message. Please try again.');
+          case '2007': // CONTEXT_PROCESSING_FAILED
+            return new Error('Failed to process document context. Please try selecting different documents.');
+          default:
+            return new Error(error.message || 'An error occurred while processing your request');
+        }
+      }
+
+      // Fallback to HTTP status codes
+      switch (error.status) {
+        case 400:
+          return new Error('Invalid request. Please check your message and try again.');
+        case 403:
+          return new Error('Access denied. You may not have permission to access these documents.');
+        case 404:
+          return new Error('Chat conversation not found.');
+        case 413:
+          return new Error('Message is too large. Please shorten your message and try again.');
+        case 429:
+          return new Error('Too many requests. Please wait a moment before trying again.');
+        case 500:
+          return new Error('Server error. Please try again later.');
+        case 503:
+          return new Error('Chat service is temporarily unavailable. Please try again later.');
+        default:
+          return new Error(error.message || 'Failed to process chat request');
+      }
+    }
+
+    if (error instanceof Error) {
+      return error;
+    }
+
+    return new Error('An unexpected error occurred while processing your chat request');
+  }
+}
+
+export const chatService = new ChatService();

--- a/frontend/src/styles/chatStyles.ts
+++ b/frontend/src/styles/chatStyles.ts
@@ -1,0 +1,214 @@
+import { COLORS } from './colors';
+import { TYPOGRAPHY_STYLES } from './typographyStyles';
+import { INPUT_BASE_CLASSES, INPUT_STATES } from './inputStyles';
+
+export const getMessageTheme = (isUser: boolean) => ({
+  backgroundColor: isUser ? COLORS.mint : COLORS.palePurple,
+  border: `1px solid ${isUser ? COLORS.forestGreen : COLORS.lavender}`,
+});
+
+export const getInteractiveButtonStyle = (variant: 'context' | 'send', state: 'default' | 'disabled' = 'default') => {
+  const baseStyle = {
+    transition: 'all 0.2s ease',
+    cursor: state === 'disabled' ? 'not-allowed' : 'pointer',
+    opacity: state === 'disabled' ? 0.5 : 1,
+  };
+
+  switch (variant) {
+    case 'context':
+      return {
+        ...baseStyle,
+        backgroundColor: COLORS.palePurple,
+        borderColor: COLORS.lavender,
+        color: COLORS.charcoal,
+      };
+    case 'send':
+      return {
+        ...baseStyle,
+        backgroundColor: state === 'disabled' ? COLORS.lavender : COLORS.forestGreen,
+        color: 'white',
+      };
+    default:
+      return baseStyle;
+  }
+};
+
+export const getBadgeStyle = (variant: 'context' | 'source') => {
+  switch (variant) {
+    case 'context':
+      return {
+        backgroundColor: COLORS.mint,
+        color: COLORS.forestGreen,
+        border: `1px solid ${COLORS.forestGreen}`,
+      };
+    case 'source':
+      return {
+        backgroundColor: COLORS.palePurple,
+        borderColor: COLORS.lavender,
+      };
+    default:
+      return {};
+  }
+};
+
+export const chatStyles = {
+  messageBubble: {
+    base: 'rounded-2xl px-4 py-3',
+    userVariant: 'rounded-br-md',
+    assistantVariant: 'rounded-bl-md',
+    getThemeStyle: getMessageTheme,
+  },
+
+  messageContainer: {
+    wrapper: (isUser: boolean) => `flex ${isUser ? 'justify-end' : 'justify-start'}`,
+    content: (isUser: boolean) => `max-w-[80%] ${isUser ? 'ml-12' : 'mr-12'}`,
+    timestamp: (isUser: boolean) => `mt-1 text-xs ${isUser ? 'text-right' : 'text-left'}`,
+  },
+
+  sourcesSection: {
+    container: 'mt-3',
+    toggleButton: `flex items-center gap-2 text-sm font-medium transition-colors hover:opacity-75 ${TYPOGRAPHY_STYLES.interactive.link}`,
+    expandedContainer: 'mt-2 space-y-2',
+    sourceItem: {
+      base: 'p-3 rounded-lg border cursor-pointer transition-all hover:shadow-sm',
+      getStyle: () => getBadgeStyle('source'),
+    },
+    sourceHeader: 'flex items-center gap-2 mb-1',
+    sourceTitle: `${TYPOGRAPHY_STYLES.body.base} font-medium`,
+    sourceExcerpt: `${TYPOGRAPHY_STYLES.secondary.small} leading-relaxed`,
+  },
+
+  contextDisplay: {
+    container: 'mb-3 flex flex-wrap gap-2',
+    label: `${TYPOGRAPHY_STYLES.body.base} font-medium`,
+    badge: {
+      base: 'inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium',
+      getStyle: () => getBadgeStyle('context'),
+    },
+    removeButton: 'ml-1 hover:opacity-75',
+  },
+
+  messageInput: {
+    container: 'flex gap-3 items-end',
+    textareaWrapper: 'flex-1 relative',
+    textarea: {
+      base: `w-full resize-none ${INPUT_BASE_CLASSES} ${INPUT_STATES.default}`,
+      style: {
+        minHeight: '44px',
+        maxHeight: '120px',
+        paddingRight: '60px',
+      },
+    },
+    contextButton: {
+      base: 'flex-shrink-0 p-3 rounded-lg border transition-all hover:shadow-sm',
+      getStyle: () => getInteractiveButtonStyle('context'),
+    },
+    sendButton: {
+      base: 'absolute right-2 bottom-2 p-2 rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed',
+      getStyle: (canSend: boolean, isLoading: boolean) =>
+        getInteractiveButtonStyle('send', (!canSend || isLoading) ? 'disabled' : 'default'),
+    },
+    hints: `mt-2 ${TYPOGRAPHY_STYLES.secondary.small}`,
+  },
+
+  chatInput: {
+    container: {
+      base: 'border-t p-4',
+      style: {
+        borderColor: COLORS.lavender,
+      },
+    },
+  },
+
+  loadingSpinner: {
+    base: 'w-4 h-4 animate-spin rounded-full border-2 border-white border-t-transparent',
+  },
+
+  layout: {
+    flexCenter: 'flex items-center justify-center',
+    flexBetween: 'flex items-center justify-between',
+    flexStart: 'flex items-center justify-start',
+    flexEnd: 'flex items-center justify-end',
+    spacingSmall: 'gap-2',
+    spacingMedium: 'gap-3',
+    spacingLarge: 'gap-4',
+  },
+
+  interactive: {
+    hover: 'hover:opacity-75 transition-opacity',
+    clickable: 'cursor-pointer transition-all',
+    disabled: 'opacity-50 cursor-not-allowed',
+    loading: 'opacity-75 pointer-events-none',
+  },
+  animations: {
+    fadeIn: 'animate-fade-in',
+    slideIn: 'animate-slide-in',
+    spin: 'animate-spin',
+    pulse: 'animate-pulse',
+  },
+
+  chatHeader: {
+    container: {
+      base: 'border-b px-6 py-4 flex items-center justify-between',
+      style: {
+        backgroundColor: 'white',
+        borderColor: COLORS.lavender,
+      },
+    },
+    leftSection: 'flex items-center gap-4',
+    menuButton: {
+      base: 'p-3 rounded-lg transition-all hover:shadow-sm',
+      getStyle: () => getInteractiveButtonStyle('context'),
+    },
+    organizationDisplay: {
+      container: 'text-center',
+      title: TYPOGRAPHY_STYLES.headings.h1,
+      orgInfo: 'flex items-center justify-center gap-2 mt-1',
+      orgName: TYPOGRAPHY_STYLES.secondary.base,
+      roleBadge: 'px-2 py-1 rounded-full text-xs font-medium',
+    },
+    profileDropdown: {
+      container: 'relative',
+      trigger: {
+        base: 'flex items-center gap-2 p-3 rounded-lg transition-all hover:shadow-sm',
+        getStyle: () => getBadgeStyle('context'),
+      },
+      avatar: 'w-8 h-8 rounded-full bg-white flex items-center justify-center',
+      userName: `${TYPOGRAPHY_STYLES.body.base} font-medium hidden sm:block`,
+      dropdown: {
+        container: 'absolute top-full right-0 mt-1 bg-white border rounded-lg shadow-lg z-10 min-w-48',
+        style: { borderColor: COLORS.lavender },
+        userInfo: {
+          container: 'p-3 border-b',
+          style: { borderColor: COLORS.lavender },
+          name: `${TYPOGRAPHY_STYLES.body.base} font-medium`,
+          email: TYPOGRAPHY_STYLES.secondary.small,
+        },
+        menu: 'p-1',
+        menuItem: 'w-full p-2 text-left hover:bg-gray-50 rounded transition-colors',
+        menuItemText: TYPOGRAPHY_STYLES.body.base,
+        divider: { style: { borderColor: COLORS.lavender } },
+        logoutItem: 'w-full p-2 text-left hover:bg-gray-50 rounded transition-colors text-red-600',
+      },
+    },
+  },
+};
+
+export const getRoleBadgeStyle = (role: string) => {
+  const roleColors = {
+    ADMIN: { backgroundColor: COLORS.forestGreen, color: 'white' },
+    MANAGER: { backgroundColor: COLORS.mint, color: COLORS.forestGreen },
+    MEMBER: { backgroundColor: COLORS.palePurple, color: COLORS.lavender },
+    VIEWER: { backgroundColor: COLORS.oatMilk, color: COLORS.charcoal },
+  };
+
+  return roleColors[role as keyof typeof roleColors] || roleColors.MEMBER;
+};
+
+export const combineStyles = (...styles: (string | undefined)[]): string => {
+  return styles.filter(Boolean).join(' ');
+};
+
+export const getConditionalStyle = (condition: boolean, trueStyle: string, falseStyle: string = ''): string => {
+  return condition ? trueStyle : falseStyle;
+};


### PR DESCRIPTION
This PR is to create the components for the chat page. I basically just made the design similar to ChatGPT.

ChatArea (Main container)
|---- ChatMessages (Message display)
│        |── MessageContainer (Individual message wrapper)
│        |── MessageBubble (Message content)
│        |── SourcesSection (Expandable sources)
│    |── EmptyState (No messages state)
|── ChatInput (Input interface)
│         |── ContextDisplay (Selected context badges)
│         |── MessageInput (Text area with send button)
|── DocumentContextModal (Document selection)
          |── SearchInput (Document filtering)
          |── DocumentItem (Recursive document tree)
          |── ActionButtons (Apply/Cancel)
          
Hooks:
- useChat: Main chat state management (messages, context, loading)
- useMessageInput: handles input with resizing
- useSourceExpansion: manages which message sources are expanded

chatService: just filled with mock data for now and will be implemented later after the document processing, embedding, search, and other chat stuff is done on the backend