### PR TITLE
Rag complete

### DIFF
--- a/pythonService/app/services/llm_service.py
+++ b/pythonService/app/services/llm_service.py
@@ -1,7 +1,6 @@
 import logging
-from typing import Optional
 import google.generativeai as genai
-from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+from tenacity import retry, stop_after_attempt, retry_if_exception_type
 
 from app.config import get_settings
 from ollama import chat
@@ -30,8 +29,7 @@ class LLMService:
             self.gemini_client = genai.GenerativeModel(self.gemini_model)
 
     @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=2, min=8, max=60),
+        stop=stop_after_attempt(2),
         retry=retry_if_exception_type((Exception,))
     )
     async def _call_gemini_model(self, prompt: str, **kwargs) -> str:
@@ -93,6 +91,232 @@ class LLMService:
             logger.error(f"Error calling LLM model with provider {self.provider}: {e}")
             raise
 
+    async def enhance_query(self, query: str, conversation_history: list = []) -> list[str]:
+        """
+        Generate 1-5 enhanced search queries from user input
+        """
+        try:
+            logger.info(f"QUERY ENHANCEMENT - Original query: '{query}'")
+
+            conversation_context = ""
+            if conversation_history:
+                recent_history = conversation_history[-3:]  # Last 3 exchanges
+                conversation_context = "\n".join([
+                    f"User: {msg.get('query', '')}\nAssistant: {msg.get('answer', '')}"
+                    for msg in recent_history if msg.get('query')
+                ])
+                conversation_context = f"\n\nConversation History:\n{conversation_context}\n"
+                logger.debug(f"Using conversation context: {len(recent_history)} previous exchanges")
+
+            prompt = f"""You are a query enhancement specialist. Your task is to generate multiple search queries that will help find the most relevant information to answer the user's question.
+
+                    {conversation_context}
+                    Current User Query: "{query}"
+
+                    Generate 1-5 diverse search queries that would help find relevant information. Include:
+                    1. The original query (reformulated if needed)
+                    2. Keyword-focused variants for specific terms
+                    3. Semantic variants that capture the intent
+                    4. Related concept queries if applicable
+
+                    Format your response as a JSON array of strings, like this:
+                    ["query 1", "query 2", "query 3"]
+
+                    Do NOT include any explanatory text, reasoning, or additional commentary
+                    Focus on creating queries that would retrieve different but relevant perspectives on the topic."""
+
+            logger.debug(f"QUERY ENHANCEMENT PROMPT:\n{prompt}")
+            response = await self.call_model(prompt, temperature=0.3)
+            logger.info(f"QUERY ENHANCEMENT RESPONSE:\n{response}")
+
+            import json
+            try:
+                enhanced_queries = json.loads(response.strip())
+                if isinstance(enhanced_queries, list) and len(enhanced_queries) > 0:
+                    if query not in enhanced_queries:
+                        enhanced_queries.insert(0, query)
+                    return enhanced_queries[:5]
+                else:
+                    logger.warning("LLM returned invalid query enhancement format, using original query")
+                    return [query]
+            except json.JSONDecodeError:
+                logger.warning("Failed to parse LLM query enhancement response, using original query")
+                return [query]
+
+        except Exception as e:
+            logger.error(f"Error in query enhancement: {e}")
+            return [query]
+
+    async def select_context(self, query: str, candidate_chunks: list) -> list[dict]:
+        try:
+            logger.info(f"CONTEXT SELECTION - Query: '{query}' | Candidates: {len(candidate_chunks)}")
+
+            if not candidate_chunks:
+                logger.warning("No candidate chunks provided for context selection")
+                return []
+
+            candidates = candidate_chunks[:15]
+            logger.debug(f"Limited candidates to {len(candidates)} chunks to prevent token overflow")
+
+            formatted_candidates = []
+            for i, chunk in enumerate(candidates):
+                doc_title = chunk.get('metadata', {}).get('document_title', 'Unknown')
+                content_preview = chunk['content'][:500] + ('...' if len(chunk['content']) > 500 else '')
+                score = chunk['score']
+
+                formatted_candidates.append(
+                    f"[{i+1}] Document: {doc_title}\n"
+                    f"Content: {content_preview}\n"
+                    f"Score: {score:.3f}"
+                )
+
+                logger.debug(f"Candidate {i+1}: {doc_title} (score: {score:.3f})")
+
+            candidates_text = "\n\n".join(formatted_candidates)
+
+            prompt = f"""You are a context selection specialist. Your task is to select the most relevant document chunks that will help answer the user's question.
+
+                    User Question: "{query}"
+
+                    Available Document Chunks:
+                    {candidates_text}
+
+                    Select the 3-5 most relevant chunks that would best help answer the user's question. Consider:
+                    1. Direct relevance to the question
+                    2. Complementary information that provides complete context
+                    3. Avoid redundant or duplicate information
+                    4. Prioritize chunks with higher relevance scores when relevance is similar
+
+                    Respond with a JSON array of the chunk numbers (1-based indexing) you want to select, like this:
+                    [1, 3, 5]
+
+                    If none of the chunks are relevant, respond with an empty array like this:
+                    []
+
+                    Do NOT include any explanatory text, reasoning, or additional commentary. Only respond with the JSON array.
+                    Select only the chunk numbers, not the content."""
+
+            logger.debug(f"CONTEXT SELECTION PROMPT:\n{prompt}")
+            response = await self.call_model(prompt, temperature=0.1)
+            logger.info(f"CONTEXT SELECTION RESPONSE:\n{response}")
+
+            import json
+            try:
+                selected_indices = json.loads(response.strip())
+                if isinstance(selected_indices, list):
+                    selected_chunks = []
+                    for idx in selected_indices:
+                        if isinstance(idx, int) and 1 <= idx <= len(candidates):
+                            selected_chunks.append(candidates[idx - 1])
+
+                    if not selected_chunks:
+                        logger.info("LLM determined no chunks are relevant - returning empty context")
+                        return []
+
+                    return selected_chunks[:5]
+                else:
+                    logger.warning("LLM returned invalid context selection format")
+                    return sorted(candidates[:3], key=lambda x: x['score'], reverse=True)
+            except json.JSONDecodeError:
+                logger.warning("Failed to parse LLM context selection response")
+                return sorted(candidates[:3], key=lambda x: x['score'], reverse=True)
+
+        except Exception as e:
+            logger.error(f"Error in context selection: {e}")
+            return sorted(candidate_chunks[:3], key=lambda x: x['score'], reverse=True)
+
+    async def generate_answer(self, query: str, context_chunks: list, conversation_history: list = None) -> dict:
+        try:
+            logger.info(f"ANSWER GENERATION - Query: '{query}' | Context chunks: {len(context_chunks)}")
+
+            if not context_chunks:
+                logger.warning("No context chunks provided for answer generation")
+                return {
+                    "answer": "I don't have enough information in the available documents to answer your question.",
+                    "sources": [],
+                    "confidence": "low"
+                }
+
+            formatted_context = []
+            sources = []
+
+            for i, chunk in enumerate(context_chunks):
+                doc_title = chunk.get('metadata', {}).get('document_title', 'Unknown Document')
+                formatted_context.append(
+                    f"[Source {i+1}] {doc_title}:\n{chunk['content']}"
+                )
+
+                logger.debug(f"Source {i+1}: {doc_title} | Score: {chunk.get('score', 0.0):.3f}")
+
+                sources.append({
+                    "chunk_id": chunk.get('chunk_id', f'chunk-{i}'),
+                    "document_id": chunk.get('document_id', f'doc-{i}'),
+                    "document_title": doc_title,
+                    "content": chunk['content'][:200] + "..." if len(chunk['content']) > 200 else chunk['content'],
+                    "relevance_score": chunk.get('score', 0.0),
+                    "page_number": chunk.get('metadata', {}).get('page_number'),
+                    "source_number": i + 1
+                })
+            if context_chunks:
+                context_text = "\n\n".join(formatted_context)
+            else:
+                context_text = "\n\n No context was found for this query."
+
+            conversation_context = ""
+            if conversation_history:
+                recent_history = conversation_history[-2:]  # Last 2 exchanges
+                conversation_context = "\n\nRecent Conversation:\n" + "\n".join([
+                    f"Q: {msg.get('query', '')}\nA: {msg.get('answer', '')}"
+                    for msg in recent_history if msg.get('query')
+                ])
+                logger.debug(f"Using conversation history: {len(recent_history)} previous exchanges")
+
+            prompt = f"""You are a helpful AI assistant that answers questions based on provided document context. Your task is to provide accurate, comprehensive answers using only the information from the given sources.
+
+                    {conversation_context}
+
+                    User Question: "{query}"
+
+                    Available Context:
+                    {context_text}
+
+                    Instructions:
+                    1. Answer the question using ONLY the information provided in the context
+                    2. Be comprehensive but concise
+                    3. If the context doesn't contain enough information, say so clearly
+                    4. Reference specific sources when making claims (e.g., "According to Source 1...")
+                    5. If multiple sources provide different perspectives, acknowledge this
+                    6. Do not make up information not present in the context
+                    7. If the question cannot be answered with the given context, explain what information would be needed
+
+                    Provide a clear, well-structured answer that directly addresses the user's question."""
+
+            logger.debug(f"ANSWER GENERATION PROMPT:\n{prompt}")
+            response = await self.call_model(prompt, temperature=0.2)
+            logger.info(f"ANSWER GENERATION RESPONSE:\n{response}")
+
+            # Determine confidence based on context quality and coverage
+            confidence = "high"
+            if len(context_chunks) < 2:
+                confidence = "medium"
+            if not any(chunk['score'] > 0.7 for chunk in context_chunks):
+                confidence = "medium"
+            if "don't have enough information" in response.lower() or "cannot be answered" in response.lower():
+                confidence = "low"
+
+            return {
+                "answer": response.strip(),
+                "sources": sources,
+                "confidence": confidence
+            }
+
+        except Exception as e:
+            logger.error(f"Error in answer generation: {e}")
+            return {
+                "answer": "I encountered an error while generating the answer. Please try again.",
+                "sources": [],
+                "confidence": "low"
+            }
 
     async def cleanup(self) -> None:
         logger.info("Cleaning up LLMService")

--- a/pythonService/tests/conftest.py
+++ b/pythonService/tests/conftest.py
@@ -53,13 +53,6 @@ async def setup_test_database():
     yield
 
     try:
-        from app.services.cleanup_manager import cleanup_manager
-        await cleanup_manager.cleanup_all_services()
-        logger.info("Completed cleanup of all singleton services")
-    except Exception as e:
-        logger.error(f"Error during service cleanup: {e}")
-
-    try:
         conn = await asyncpg.connect(settings.DATABASE_URL.replace("/teamquery_test", "/postgres"))
         await conn.execute("DROP DATABASE teamquery_test WITH (FORCE)")
         await conn.close()

--- a/pythonService/tests/e2e/test_rag_pipeline.py
+++ b/pythonService/tests/e2e/test_rag_pipeline.py
@@ -1,0 +1,396 @@
+import pytest
+import asyncio
+from httpx import AsyncClient
+from typing import Dict, Any
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestRAGPipeline:
+
+    @pytest.fixture(scope="class")
+    def event_loop(self):
+        """Class-scoped event loop to run all tests in same loop"""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        yield loop
+        loop.close()
+
+    @pytest.mark.e2e
+    async def test_rag_query_full_pipeline(
+        self,
+        test_client: AsyncClient,
+        mock_search_data: Dict[str, Any],
+    ):
+        """Test the complete RAG pipeline from query to answer generation"""
+        org_id = mock_search_data["org_id"]
+        test_users = mock_search_data["test_users"]
+        admin_user = test_users["admin"]
+
+        rag_request = {
+            "query": "What are the project management guidelines?",
+            "organization_id": org_id,
+            "conversation_id": "test-conversation-1",
+            "filters": {
+                "permissions": {
+                    "userId": admin_user["userId"],
+                    "userRole": admin_user["userRole"],
+                    "userGroupIds": admin_user["userGroupIds"]
+                }
+            },
+            "max_context_chunks": 3
+        }
+
+        response = await test_client.post("/api/search/rag-query", json=rag_request)
+
+        assert response.status_code == 200
+        rag_response = response.json()
+
+        assert "query" in rag_response
+        assert "answer" in rag_response
+        assert "sources" in rag_response
+        assert "conversation_id" in rag_response
+        assert "processing_time" in rag_response
+
+        assert rag_response["query"] == rag_request["query"]
+        assert rag_response["conversation_id"] == rag_request["conversation_id"]
+        assert isinstance(rag_response["answer"], str)
+        assert len(rag_response["answer"]) > 0
+        assert isinstance(rag_response["sources"], list)
+        assert rag_response["processing_time"] > 0
+
+        if len(rag_response["sources"]) > 0:
+            source = rag_response["sources"][0]
+            assert "chunk_id" in source
+            assert "document_id" in source
+            assert "document_title" in source
+            assert "content" in source
+            assert "relevance_score" in source
+
+            assert len(source["content"]) > 0
+            assert isinstance(source["relevance_score"], (int, float))
+            assert source["relevance_score"] > 0
+
+    @pytest.mark.e2e
+    async def test_rag_query_with_permission_filtering(
+        self,
+        test_client: AsyncClient,
+        mock_search_data: Dict[str, Any]
+    ):
+        """Test that RAG respects permission filtering"""
+        org_id = mock_search_data["org_id"]
+        test_users = mock_search_data["test_users"]
+
+        # Test with public user (limited permissions)
+        public_user = test_users["public_user"]
+        rag_request = {
+            "query": "What are the security protocols?",  # Should be admin-only content
+            "organization_id": org_id,
+            "filters": {
+                "permissions": {
+                    "userId": public_user["userId"],
+                    "userRole": public_user["userRole"],
+                    "userGroupIds": public_user["userGroupIds"]
+                }
+            },
+            "max_context_chunks": 5
+        }
+
+        response = await test_client.post("/api/search/rag-query", json=rag_request)
+        assert response.status_code == 200
+        public_response = response.json()
+
+        # Test with admin user (full permissions)
+        admin_user = test_users["admin"]
+        rag_request["filters"]["permissions"] = {
+            "userId": admin_user["userId"],
+            "userRole": admin_user["userRole"],
+            "userGroupIds": admin_user["userGroupIds"]
+        }
+
+        response = await test_client.post("/api/search/rag-query", json=rag_request)
+        assert response.status_code == 200
+        admin_response = response.json()
+
+        for source in public_response["sources"]:
+            source_metadata = source.get("metadata", {})
+            access_level = source_metadata.get("accessLevel")
+            group_id = source_metadata.get("groupId")
+            restricted_to_users = source_metadata.get("restrictedToUsers")
+
+            public_user = test_users["public_user"]
+
+            if access_level:
+                can_access = False
+
+                if access_level == "PUBLIC":
+                    can_access = True
+                if access_level == "GROUP" and group_id:
+                    can_access = group_id in public_user["userGroupIds"]
+                elif access_level == "RESTRICTED" and restricted_to_users:
+                    can_access = public_user["userId"] in restricted_to_users
+
+                assert can_access, f"Public user received content they cannot access: {access_level}"
+
+        for source in admin_response["sources"]:
+            source_metadata = source.get("metadata", {})
+            access_level = source_metadata.get("accessLevel")
+
+            if access_level:
+                valid_access_levels = ["PUBLIC", "GROUP", "MANAGERS", "ADMINS", "RESTRICTED"]
+                assert access_level in valid_access_levels, f"Invalid access level found: {access_level}"
+
+            assert "content" in source, "Source missing content field"
+            assert len(source["content"]) > 0, "Source has empty content"
+
+    @pytest.mark.e2e
+    async def test_rag_query_no_results_scenario(
+        self,
+        test_client: AsyncClient,
+        mock_search_data: Dict[str, Any]
+    ):
+        """Test RAG behavior when no relevant documents are found"""
+        org_id = mock_search_data["org_id"]
+        test_users = mock_search_data["test_users"]
+        admin_user = test_users["admin"]
+
+        # Query for something that shouldn't exist in the mock data
+        rag_request = {
+            "query": "What is the quantum physics theory of relativity in space exploration?",
+            "organization_id": org_id,
+            "filters": {
+                "permissions": {
+                    "userId": admin_user["userId"],
+                    "userRole": admin_user["userRole"],
+                    "userGroupIds": admin_user["userGroupIds"]
+                }
+            },
+            "max_context_chunks": 3
+        }
+
+        response = await test_client.post("/api/search/rag-query", json=rag_request)
+        assert response.status_code == 200
+        rag_response = response.json()
+
+        assert "answer" in rag_response
+        assert "sources" in rag_response
+
+        answer_lower = rag_response["answer"].lower()
+        assert any(phrase in answer_lower for phrase in [
+            "couldn't find", "no information", "don't have", "not found"
+        ])
+
+        assert len(rag_response["sources"]) == 0
+
+    @pytest.mark.e2e
+    async def test_rag_query_with_different_max_context_chunks(
+        self,
+        test_client: AsyncClient,
+        mock_search_data: Dict[str, Any]
+    ):
+        org_id = mock_search_data["org_id"]
+        test_users = mock_search_data["test_users"]
+        admin_user = test_users["admin"]
+
+        base_request = {
+            "query": "What are the company policies?",
+            "organization_id": org_id,
+            "filters": {
+                "permissions": {
+                    "userId": admin_user["userId"],
+                    "userRole": admin_user["userRole"],
+                    "userGroupIds": admin_user["userGroupIds"]
+                }
+            }
+        }
+
+        for max_chunks in [1, 3, 5]:
+            request = {**base_request, "max_context_chunks": max_chunks}
+
+            response = await test_client.post("/api/search/rag-query", json=request)
+            assert response.status_code == 200
+            rag_response = response.json()
+
+            assert len(rag_response["sources"]) <= max_chunks
+            assert len(rag_response["answer"]) > 0
+
+    @pytest.mark.e2e
+    async def test_rag_query_error_handling(
+        self,
+        test_client: AsyncClient,
+        mock_search_data: Dict[str, Any]
+    ):
+        org_id = mock_search_data["org_id"]
+        test_users = mock_search_data["test_users"]
+        admin_user = test_users["admin"]
+
+        # Test with invalid organization ID
+        invalid_request = {
+            "query": "Test query",
+            "organization_id": "non-existent-org",
+            "filters": {
+                "permissions": {
+                    "userId": admin_user["userId"],
+                    "userRole": admin_user["userRole"],
+                    "userGroupIds": admin_user["userGroupIds"]
+                }
+            }
+        }
+
+        response = await test_client.post("/api/search/rag-query", json=invalid_request)
+        assert response.status_code == 200  # Should return graceful error response
+        rag_response = response.json()
+
+        # Should contain error message in answer
+        assert "error" in rag_response["answer"].lower() or "couldn't find" in rag_response["answer"].lower()
+        assert len(rag_response["sources"]) == 0
+
+        # Test with missing required fields
+        incomplete_request = {
+            "query": "Test query"
+            # Missing organization_id
+        }
+
+        response = await test_client.post("/api/search/rag-query", json=incomplete_request)
+        assert response.status_code == 422  # Validation error
+
+    @pytest.mark.e2e
+    async def test_rag_query_processing_time_reasonable(
+        self,
+        test_client: AsyncClient,
+        mock_search_data: Dict[str, Any]
+    ):
+        org_id = mock_search_data["org_id"]
+        test_users = mock_search_data["test_users"]
+        admin_user = test_users["admin"]
+
+        rag_request = {
+            "query": "What are the main topics covered in the documents?",
+            "organization_id": org_id,
+            "filters": {
+                "permissions": {
+                    "userId": admin_user["userId"],
+                    "userRole": admin_user["userRole"],
+                    "userGroupIds": admin_user["userGroupIds"]
+                }
+            },
+            "max_context_chunks": 3
+        }
+
+        response = await test_client.post("/api/search/rag-query", json=rag_request)
+        assert response.status_code == 200
+        rag_response = response.json()
+
+        assert rag_response["processing_time"] < 30.0
+        assert rag_response["processing_time"] > 0
+
+    @pytest.mark.e2e
+    async def test_rag_query_conversation_id_passthrough(
+        self,
+        test_client: AsyncClient,
+        mock_search_data: Dict[str, Any]
+    ):
+        org_id = mock_search_data["org_id"]
+        test_users = mock_search_data["test_users"]
+        admin_user = test_users["admin"]
+
+        conversation_id = "test-conversation-12345"
+        rag_request = {
+            "query": "Test query for conversation tracking",
+            "organization_id": org_id,
+            "conversation_id": conversation_id,
+            "filters": {
+                "permissions": {
+                    "userId": admin_user["userId"],
+                    "userRole": admin_user["userRole"],
+                    "userGroupIds": admin_user["userGroupIds"]
+                }
+            }
+        }
+
+        response = await test_client.post("/api/search/rag-query", json=rag_request)
+        assert response.status_code == 200
+        rag_response = response.json()
+
+        assert rag_response["conversation_id"] == conversation_id
+
+    @pytest.mark.e2e
+    async def test_rag_query_source_attribution(
+        self,
+        test_client: AsyncClient,
+        mock_search_data: Dict[str, Any]
+    ):
+        org_id = mock_search_data["org_id"]
+        test_users = mock_search_data["test_users"]
+        admin_user = test_users["admin"]
+
+        rag_request = {
+            "query": "What information is available about projects?",
+            "organization_id": org_id,
+            "filters": {
+                "permissions": {
+                    "userId": admin_user["userId"],
+                    "userRole": admin_user["userRole"],
+                    "userGroupIds": admin_user["userGroupIds"]
+                }
+            },
+            "max_context_chunks": 3
+        }
+
+        response = await test_client.post("/api/search/rag-query", json=rag_request)
+        assert response.status_code == 200
+        rag_response = response.json()
+
+        for source in rag_response["sources"]:
+            assert isinstance(source["chunk_id"], str)
+            assert len(source["chunk_id"]) > 0
+            assert isinstance(source["document_id"], str)
+            assert len(source["document_id"]) > 0
+            assert isinstance(source["document_title"], str)
+            assert isinstance(source["content"], str)
+            assert len(source["content"]) > 0
+            assert isinstance(source["relevance_score"], (int, float))
+            assert source["relevance_score"] > 0
+
+            assert "page_number" in source
+
+    @pytest.mark.e2e
+    async def test_rag_query_with_index_rebuild(
+        self,
+        test_client: AsyncClient,
+        mock_search_data: Dict[str, Any]
+    ):
+        org_id = mock_search_data["org_id"]
+        test_users = mock_search_data["test_users"]
+        admin_user = test_users["admin"]
+
+        rag_request = {
+            "query": "What are the organizational guidelines?",
+            "organization_id": org_id,
+            "filters": {
+                "permissions": {
+                    "userId": admin_user["userId"],
+                    "userRole": admin_user["userRole"],
+                    "userGroupIds": admin_user["userGroupIds"]
+                }
+            }
+        }
+
+        response1 = await test_client.post("/api/search/rag-query", json=rag_request)
+        assert response1.status_code == 200
+        first_response = response1.json()
+
+        rebuild_response = await test_client.post(
+            "/api/search/rebuild-index",
+            json={"organization_id": org_id}
+        )
+        assert rebuild_response.status_code == 200
+
+        response2 = await test_client.post("/api/search/rag-query", json=rag_request)
+        assert response2.status_code == 200
+        second_response = response2.json()
+
+        assert len(second_response["answer"]) > 0
+        assert isinstance(second_response["sources"], list)
+
+        assert second_response["query"] == first_response["query"]

--- a/pythonService/tests/integration/test_llm_service_gemini_integration.py
+++ b/pythonService/tests/integration/test_llm_service_gemini_integration.py
@@ -1,0 +1,343 @@
+import pytest
+import asyncio
+import os
+from app.services.llm_service import LLMService
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestLLMServiceGeminiIntegration:
+
+    @pytest.fixture(scope="class")
+    def event_loop(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        yield loop
+        loop.close()
+
+    @pytest.fixture(scope="class")
+    async def llm_service(self):
+        service = LLMService()
+        yield service
+        await service.cleanup()
+
+    @pytest.mark.skipif(
+        not os.getenv('GOOGLE_API_KEY'),
+        reason="GOOGLE_API_KEY not set - skipping Gemini integration tests"
+    )
+    async def test_gemini_basic_response(self, llm_service):
+        """Test that Gemini returns a basic response through call_model."""
+        if llm_service.provider != 'gemini' or not llm_service.gemini_client:
+            pytest.skip("Gemini not configured")
+
+        prompt = "What is 2 + 2? Answer with just the number."
+        response = await llm_service.call_model(prompt)
+
+        assert isinstance(response, str)
+        assert len(response.strip()) > 0
+        assert "4" in response
+
+    @pytest.mark.skipif(
+        not os.getenv('GOOGLE_API_KEY'),
+        reason="GOOGLE_API_KEY not set - skipping Gemini integration tests"
+    )
+    async def test_enhance_query_integration(self, llm_service):
+        if llm_service.provider != 'gemini' or not llm_service.gemini_client:
+            pytest.skip("Gemini not configured")
+
+        original_query = "machine learning algorithms"
+        enhanced_queries = await llm_service.enhance_query(original_query)
+
+        # Verify response structure
+        assert isinstance(enhanced_queries, list)
+        assert len(enhanced_queries) >= 1
+        assert len(enhanced_queries) <= 5
+
+        # Original query should be included
+        assert original_query in enhanced_queries
+
+        # All items should be strings
+        for query in enhanced_queries:
+            assert isinstance(query, str)
+            assert len(query.strip()) > 0
+
+    @pytest.mark.skipif(
+        not os.getenv('GOOGLE_API_KEY'),
+        reason="GOOGLE_API_KEY not set - skipping Gemini integration tests"
+    )
+    async def test_enhance_query_with_conversation_history(self, llm_service):
+        if llm_service.provider != 'gemini' or not llm_service.gemini_client:
+            pytest.skip("Gemini not configured")
+
+        conversation_history = [
+            {"query": "What is artificial intelligence?", "answer": "AI is computer intelligence"},
+            {"query": "How does it work?", "answer": "Through algorithms and data"}
+        ]
+
+        current_query = "Tell me about neural networks"
+        enhanced_queries = await llm_service.enhance_query(current_query, conversation_history)
+
+        assert isinstance(enhanced_queries, list)
+        assert current_query in enhanced_queries
+        assert len(enhanced_queries) >= 1
+
+    @pytest.mark.skipif(
+        not os.getenv('GOOGLE_API_KEY'),
+        reason="GOOGLE_API_KEY not set - skipping Gemini integration tests"
+    )
+    async def test_select_context_integration(self, llm_service):
+        if llm_service.provider != 'gemini' or not llm_service.gemini_client:
+            pytest.skip("Gemini not configured")
+
+        query = "What are the benefits of renewable energy?"
+        candidate_chunks = [
+            {
+                "chunk_id": "1",
+                "document_id": "doc1",
+                "content": "Solar energy is a renewable source that reduces carbon emissions and provides clean electricity.",
+                "score": 0.9,
+                "metadata": {"document_title": "Solar Energy Guide"}
+            },
+            {
+                "chunk_id": "2",
+                "document_id": "doc2",
+                "content": "Wind power generates electricity without pollution and is cost-effective in many regions.",
+                "score": 0.8,
+                "metadata": {"document_title": "Wind Power Analysis"}
+            },
+            {
+                "chunk_id": "3",
+                "document_id": "doc3",
+                "content": "Fossil fuels contribute to climate change and air pollution in urban areas.",
+                "score": 0.6,
+                "metadata": {"document_title": "Fossil Fuel Impact"}
+            },
+            {
+                "chunk_id": "4",
+                "document_id": "doc4",
+                "content": "The history of coal mining dates back to ancient civilizations.",
+                "score": 0.3,
+                "metadata": {"document_title": "Coal Mining History"}
+            }
+        ]
+
+        selected_chunks = await llm_service.select_context(query, candidate_chunks)
+
+        # Verify response structure
+        assert isinstance(selected_chunks, list)
+        assert len(selected_chunks) <= 5
+
+        # Should select relevant chunks (solar and wind are most relevant)
+        selected_ids = [chunk["chunk_id"] for chunk in selected_chunks]
+
+        # At least one relevant chunk should be selected
+        assert len(selected_chunks) > 0
+
+        # Verify chunk structure is preserved
+        for chunk in selected_chunks:
+            assert "chunk_id" in chunk
+            assert "content" in chunk
+            assert "score" in chunk
+
+    @pytest.mark.skipif(
+        not os.getenv('GOOGLE_API_KEY'),
+        reason="GOOGLE_API_KEY not set - skipping Gemini integration tests"
+    )
+    async def test_generate_answer_integration(self, llm_service):
+        if llm_service.provider != 'gemini' or not llm_service.gemini_client:
+            pytest.skip("Gemini not configured")
+
+        query = "What are the main benefits of solar energy?"
+        context_chunks = [
+            {
+                "chunk_id": "1",
+                "document_id": "doc1",
+                "content": "Solar energy provides clean electricity without emissions. It reduces electricity bills and increases property values.",
+                "score": 0.9,
+                "metadata": {"document_title": "Solar Benefits Guide", "page_number": 1}
+            },
+            {
+                "chunk_id": "2",
+                "document_id": "doc2",
+                "content": "Solar panels require minimal maintenance and have a lifespan of 25-30 years. They work in various weather conditions.",
+                "score": 0.8,
+                "metadata": {"document_title": "Solar Technology Overview", "page_number": 3}
+            }
+        ]
+
+        result = await llm_service.generate_answer(query, context_chunks)
+
+        assert isinstance(result, dict)
+        assert "answer" in result
+        assert "sources" in result
+        assert "confidence" in result
+
+        assert isinstance(result["answer"], str)
+        assert len(result["answer"].strip()) > 0
+
+        answer_lower = result["answer"].lower()
+        assert any(keyword in answer_lower for keyword in ["solar", "clean", "electricity", "benefit"])
+
+        assert isinstance(result["sources"], list)
+        assert len(result["sources"]) == 2
+
+        for source in result["sources"]:
+            assert "chunk_id" in source
+            assert "document_id" in source
+            assert "document_title" in source
+            assert "relevance_score" in source
+
+        assert result["confidence"] in ["low", "medium", "high"]
+
+    @pytest.mark.skipif(
+        not os.getenv('GOOGLE_API_KEY'),
+        reason="GOOGLE_API_KEY not set - skipping Gemini integration tests"
+    )
+    async def test_generate_answer_with_conversation_history(self, llm_service):
+        """Test answer generation with conversation history."""
+        if llm_service.provider != 'gemini' or not llm_service.gemini_client:
+            pytest.skip("Gemini not configured")
+
+        query = "How much does it cost?"
+        context_chunks = [
+            {
+                "chunk_id": "1",
+                "document_id": "doc1",
+                "content": "Solar panel installation costs range from $15,000 to $25,000 for residential systems.",
+                "score": 0.9,
+                "metadata": {"document_title": "Solar Costs"}
+            }
+        ]
+
+        conversation_history = [
+            {"query": "Tell me about solar energy", "answer": "Solar energy is renewable and clean"}
+        ]
+
+        result = await llm_service.generate_answer(query, context_chunks, conversation_history)
+
+        assert isinstance(result, dict)
+        assert "answer" in result
+        assert len(result["answer"].strip()) > 0
+
+        answer_lower = result["answer"].lower()
+        assert any(keyword in answer_lower for keyword in ["cost", "price", "$", "dollar"])
+
+    @pytest.mark.skipif(
+        not os.getenv('GOOGLE_API_KEY'),
+        reason="GOOGLE_API_KEY not set - skipping Gemini integration tests"
+    )
+    async def test_empty_context_handling(self, llm_service):
+        """Test service behavior with empty context."""
+        if llm_service.provider != 'gemini' or not llm_service.gemini_client:
+            pytest.skip("Gemini not configured")
+
+        query = "What is quantum computing?"
+        result = await llm_service.generate_answer(query, [])
+
+        assert isinstance(result, dict)
+        assert "answer" in result
+        assert "sources" in result
+        assert "confidence" in result
+
+        assert "don't have enough information" in result["answer"].lower()
+        assert result["sources"] == []
+        assert result["confidence"] == "low"
+
+    @pytest.mark.skipif(
+        not os.getenv('GOOGLE_API_KEY'),
+        reason="GOOGLE_API_KEY not set - skipping Gemini integration tests"
+    )
+    async def test_service_error_handling(self, llm_service):
+        """Test service error handling with invalid inputs."""
+        if llm_service.provider != 'gemini' or not llm_service.gemini_client:
+            pytest.skip("Gemini not configured")
+
+        # Test with very long prompt
+        very_long_prompt = "A" * 100000  # 100k characters
+
+        try:
+            response = await llm_service.call_model(very_long_prompt)
+            # If it succeeds, response should still be a string
+            assert isinstance(response, str)
+        except Exception as e:
+            # If it fails, it should be a proper exception
+            assert isinstance(e, Exception)
+
+    @pytest.mark.skipif(
+        not os.getenv('GOOGLE_API_KEY'),
+        reason="GOOGLE_API_KEY not set - skipping Gemini integration tests"
+    )
+    async def test_concurrent_requests(self, llm_service):
+        if llm_service.provider != 'gemini' or not llm_service.gemini_client:
+            pytest.skip("Gemini not configured")
+
+        prompts = [
+            "What is 1 + 1?",
+            "What is 2 + 2?",
+            "What is 3 + 3?"
+        ]
+
+        tasks = [llm_service.call_model(prompt) for prompt in prompts]
+        responses = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for i, response in enumerate(responses):
+            if isinstance(response, Exception):
+                assert isinstance(response, Exception)
+            else:
+                assert isinstance(response, str)
+                assert len(response.strip()) > 0
+
+    @pytest.mark.skipif(
+        not os.getenv('GOOGLE_API_KEY'),
+        reason="GOOGLE_API_KEY not set - skipping Gemini integration tests"
+    )
+    async def test_full_rag_pipeline_integration(self, llm_service):
+        if llm_service.provider != 'gemini' or not llm_service.gemini_client:
+            pytest.skip("Gemini not configured")
+
+        original_query = "renewable energy benefits"
+        enhanced_queries = await llm_service.enhance_query(original_query)
+
+        assert isinstance(enhanced_queries, list)
+        assert original_query in enhanced_queries
+
+        candidate_chunks = [
+            {
+                "chunk_id": "1",
+                "document_id": "doc1",
+                "content": "Renewable energy sources like solar and wind reduce greenhouse gas emissions significantly.",
+                "score": 0.9,
+                "metadata": {"document_title": "Climate Benefits"}
+            },
+            {
+                "chunk_id": "2",
+                "document_id": "doc2",
+                "content": "Solar energy systems can reduce electricity bills by 70-90% for homeowners.",
+                "score": 0.8,
+                "metadata": {"document_title": "Economic Benefits"}
+            },
+            {
+                "chunk_id": "3",
+                "document_id": "doc3",
+                "content": "Wind turbines create jobs in manufacturing, installation, and maintenance sectors.",
+                "score": 0.7,
+                "metadata": {"document_title": "Job Creation"}
+            }
+        ]
+
+        selected_context = await llm_service.select_context(original_query, candidate_chunks)
+
+        assert isinstance(selected_context, list)
+        assert len(selected_context) > 0
+
+        final_result = await llm_service.generate_answer(original_query, selected_context)
+
+        assert isinstance(final_result, dict)
+        assert "answer" in final_result
+        assert "sources" in final_result
+        assert "confidence" in final_result
+
+        answer_lower = final_result["answer"].lower()
+        assert any(keyword in answer_lower for keyword in ["renewable", "solar", "wind", "benefit"])
+
+        assert len(final_result["sources"]) == len(selected_context)


### PR DESCRIPTION
## Description
Complete implementation of rag-query API and tests

How it works:
User sends query along with metadata to the end point.
The query is passed to an LLM to identify if the user is asking about something that might be in their documents and creates
3-5 strings to use for search.
It goes through the search process and returns some chunks.
Another request to the LLM is sent to determine which of the returned chunks are most relevant to the user's query.
Those chunks are then used as context to generate the final response which is sent to the user.

Thorough testing for the llm service and the rag pipeline was made with pytest

## Milestones that this works towards
User can make a query related to something in their documents, and the RAG pipeline will generate a response using that data as context

## Test Plan
<img width="820" height="165" alt="Screenshot 2025-07-23 at 1 10 52 AM" src="https://github.com/user-attachments/assets/3f278826-afc4-4264-968b-3a5ab112cc77" />
<img width="873" height="319" alt="Screenshot 2025-07-23 at 1 10 59 AM" src="https://github.com/user-attachments/assets/34ff1308-f5a6-4886-ae08-2b60a7cbcdbb" />
