### PR TITLE
Heuristic recommendations - TC2

### DIFF
--- a/backend/prisma/migrations/20250725220753_add_denial_log/migration.sql
+++ b/backend/prisma/migrations/20250725220753_add_denial_log/migration.sql
@@ -1,0 +1,59 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `createdAt` on the `AuditLog` table. All the data in the column will be lost.
+  - You are about to drop the column `details` on the `AuditLog` table. All the data in the column will be lost.
+  - Made the column `targetId` on table `AuditLog` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropIndex
+DROP INDEX "AuditLog_createdAt_idx";
+
+-- AlterTable
+ALTER TABLE "AuditLog" DROP COLUMN "createdAt",
+DROP COLUMN "details",
+ADD COLUMN     "changes" JSONB,
+ADD COLUMN     "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ALTER COLUMN "targetId" SET NOT NULL;
+
+-- CreateTable
+CREATE TABLE "AccessDenialLog" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "searchQuery" TEXT NOT NULL,
+    "chunkId" TEXT NOT NULL,
+    "documentId" TEXT NOT NULL,
+    "groupId" TEXT,
+    "accessLevel" TEXT NOT NULL,
+    "denialReason" TEXT NOT NULL,
+    "similarity" DOUBLE PRECISION,
+    "metadata" JSONB,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AccessDenialLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AccessDenialLog_organizationId_idx" ON "AccessDenialLog"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "AccessDenialLog_userId_idx" ON "AccessDenialLog"("userId");
+
+-- CreateIndex
+CREATE INDEX "AccessDenialLog_groupId_idx" ON "AccessDenialLog"("groupId");
+
+-- CreateIndex
+CREATE INDEX "AccessDenialLog_timestamp_idx" ON "AccessDenialLog"("timestamp");
+
+-- CreateIndex
+CREATE INDEX "AccessDenialLog_userId_groupId_idx" ON "AccessDenialLog"("userId", "groupId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_timestamp_idx" ON "AuditLog"("timestamp");
+
+-- AddForeignKey
+ALTER TABLE "AccessDenialLog" ADD CONSTRAINT "AccessDenialLog_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AccessDenialLog" ADD CONSTRAINT "AccessDenialLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Organization {
   auditLogs         AuditLog[]
   searchQueries     SearchQuery[]
   invitations       OrganizationInvite[]
+  accessDenialLogs  AccessDenialLog[]
 
   @@index([adminUserId])
   @@index([createdBy])
@@ -84,6 +85,7 @@ model User {
   searchQueries        SearchQuery[]
   refreshTokens        RefreshToken[]
   sessions             UserSession[]
+  accessDenialLogs     AccessDenialLog[]
 
   @@index([email])
 }
@@ -146,25 +148,6 @@ model OrganizationMembership {
   @@unique([userId, organizationId])
   @@index([organizationId])
   @@index([userId])
-}
-
-model AuditLog {
-  id          String   @id @default(cuid())
-  userId      String
-  organizationId String
-  action      String
-  targetType  String
-  targetId    String?
-  details     Json?
-
-  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
-  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-
-  createdAt DateTime @default(now())
-
-  @@index([organizationId])
-  @@index([userId])
-  @@index([createdAt])
 }
 
 model Folder {
@@ -358,4 +341,48 @@ enum InviteStatus {
   ACCEPTED
   DECLINED
   CANCELLED
+}
+
+// Audit logging - for future use
+model AuditLog {
+  id             String   @id @default(cuid())
+  organizationId String
+  userId         String
+  action         String
+  targetType     String   // e.g., "organization", "group", "document"
+  targetId       String
+  changes        Json?
+  timestamp      DateTime @default(now())
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId])
+  @@index([userId])
+  @@index([timestamp])
+}
+
+// Access denial logging for recommendation system
+model AccessDenialLog {
+  id             String   @id @default(cuid())
+  organizationId String
+  userId         String
+  searchQuery    String   // The search query that triggered the denial
+  chunkId        String   // The chunk that was filtered out
+  documentId     String   // The document containing the chunk
+  groupId        String?  // The group that owns the document (if applicable)
+  accessLevel    String   // The access level that prevented access
+  denialReason   String   // Specific reason for denial (e.g., "not_in_group", "insufficient_role")
+  similarity     Float?   // The similarity score before filtering (if available)
+  metadata       Json?    // Additional context (document title, etc.)
+  timestamp      DateTime @default(now())
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId])
+  @@index([userId])
+  @@index([groupId])
+  @@index([timestamp])
+  @@index([userId, groupId]) // For finding denials by user and group
 }

--- a/pythonService/app/services/heuristic_recommendation_service.py
+++ b/pythonService/app/services/heuristic_recommendation_service.py
@@ -1,0 +1,333 @@
+import logging
+from datetime import datetime, timedelta
+from typing import Dict, List, Any
+from collections import defaultdict
+
+from app.services.database_service import database_service
+
+logger = logging.getLogger(__name__)
+
+
+class HeuristicRecommendationService:
+
+
+    def __init__(self):
+        self.min_buddy_score = 0.1
+        self.denial_lookback_days = 30
+
+    async def get_group_recommendations_for_user(
+        self,
+        user_id: str,
+        organization_id: str,
+        top_k: int = 5
+    ) -> List[Dict[str, Any]]:
+
+        user_groups = await self._get_user_groups(user_id, organization_id)
+        user_group_ids = {g["id"] for g in user_groups}
+
+        buddies = await self._find_group_buddies(user_id, organization_id, user_groups)
+
+        denials = await self._get_user_access_denials(user_id, organization_id)
+        denial_groups = {d["group_id"] for d in denials if d["group_id"]}
+
+        group_scores = {}
+
+        all_groups = await self._get_all_groups(organization_id)
+
+        for group in all_groups:
+            if group["id"] in user_group_ids:
+                continue  # Skip groups user is already in
+
+            score_components = {
+                "buddy_score": 0.0,
+                "denial_resolution_score": 0.0,
+                "friends_of_friends_score": 0.0,
+                "frustration_reduction": 0.0
+            }
+
+            # how many buddies are in this group
+            buddies_in_group = []
+            for buddy_id, buddy_info in buddies.items():
+                if group["id"] in buddy_info["groups"]:
+                    buddies_in_group.append((buddy_id, buddy_info["score"]))
+
+            if buddies_in_group:
+                # Weight by buddy relationship strength
+                score_components["buddy_score"] = sum(
+                    score for _, score in buddies_in_group
+                ) / len(buddies_in_group)
+
+            if group["id"] in denial_groups:
+                denials_for_group = [d for d in denials if d["group_id"] == group["id"]]
+                score_components["denial_resolution_score"] = len(denials_for_group) / 10.0
+
+                frustration = self._calculate_frustration_score(denials_for_group)
+                score_components["frustration_reduction"] = frustration
+
+            fof_score = await self._calculate_friends_of_friends_score(
+                user_id, group["id"], buddies, organization_id
+            )
+            score_components["friends_of_friends_score"] = fof_score
+
+            final_score = (
+                score_components["buddy_score"] * 0.3 +
+                score_components["denial_resolution_score"] * 0.3 +
+                score_components["frustration_reduction"] * 0.2 +
+                score_components["friends_of_friends_score"] * 0.2
+            )
+
+            if final_score > 0:
+                group_scores[group["id"]] = {
+                    "group": group,
+                    "score": final_score,
+                    "components": score_components,
+                    "buddies_in_group": [b[0] for b in buddies_in_group],
+                    "denials_resolved": len([d for d in denials if d["group_id"] == group["id"]])
+                }
+
+        recommendations = sorted(
+            group_scores.values(),
+            key=lambda x: x["score"],
+            reverse=True
+        )[:top_k]
+
+        return [
+            {
+                "group_id": rec["group"]["id"],
+                "group_name": rec["group"]["name"],
+                "score": rec["score"],
+                "reason": self._generate_recommendation_reason(rec),
+                "details": {
+                    "buddies_in_group": rec["buddies_in_group"],
+                    "denials_that_would_be_resolved": rec["denials_resolved"],
+                    "score_breakdown": rec["components"]
+                }
+            }
+            for rec in recommendations
+        ]
+
+    async def _find_group_buddies(
+        self,
+        user_id: str,
+        organization_id: str,
+        user_groups: List[Dict]
+    ) -> Dict[str, Dict]:
+        if not user_groups:
+            return {}
+
+        def create_buddy_info():
+            return {
+                "shared_groups": [],
+                "join_time_deltas": [],
+                "permissions_match": 0,
+                "total_interactions": 0,
+                "buddy_name": ""
+            }
+
+        buddies = defaultdict(create_buddy_info)
+
+        group_ids = [g["id"] for g in user_groups]
+
+        query = """
+            SELECT
+                gm."userId" as buddy_id,
+                gm."groupId" as group_id,
+                gm."joinedAt",
+                gm."canUpload",
+                gm."canDelete",
+                g.name as group_name,
+                u.name as buddy_name
+            FROM "GroupMembership" gm
+            INNER JOIN "Group" g ON g.id = gm."groupId"
+            INNER JOIN "User" u ON u.id = gm."userId"
+            WHERE gm."groupId" = ANY($1)
+              AND gm."userId" != $2
+              AND g."organizationId" = $3
+        """
+
+        async with database_service.pool.acquire() as conn:
+            rows = await conn.fetch(query, group_ids, user_id, organization_id)
+
+            for row in rows:
+                buddy_id = row["buddy_id"]
+                group_id = row["group_id"]
+
+                buddies[buddy_id]["shared_groups"].append(group_id)
+
+                user_join_time = next(
+                    (g["joined_at"] for g in user_groups if g["id"] == group_id),
+                    None
+                )
+                if user_join_time and row["joinedAt"]:
+                    time_delta = abs((user_join_time - row["joinedAt"]).days)
+                    buddies[buddy_id]["join_time_deltas"].append(time_delta)
+
+                user_permissions = next(
+                    ((g["can_upload"], g["can_delete"]) for g in user_groups if g["id"] == group_id),
+                    (False, False)
+                )
+                buddy_permissions = (row["canUpload"], row["canDelete"])
+                if user_permissions == buddy_permissions:
+                    buddies[buddy_id]["permissions_match"] += 1
+
+                buddies[buddy_id]["buddy_name"] = row["buddy_name"]
+
+        scored_buddies = {}
+        for buddy_id, info in buddies.items():
+            if not info["shared_groups"]:
+                continue
+
+            # Shared group score
+            shared_group_score = len(info["shared_groups"]) / len(user_groups)
+
+            # Time score
+            if info["join_time_deltas"]:
+                avg_time_delta = sum(info["join_time_deltas"]) / len(info["join_time_deltas"])
+                time_score = max(0, 1 - (avg_time_delta / 365))
+            else:
+                time_score = 0
+                avg_time_delta = 0
+
+            # Permission match score
+            permission_score = info["permissions_match"] / len(info["shared_groups"])
+
+            buddy_score = (
+                shared_group_score * 0.5 +
+                time_score * 0.3 +
+                permission_score * 0.2
+            )
+
+            if buddy_score >= self.min_buddy_score:
+                scored_buddies[buddy_id] = {
+                    "score": buddy_score,
+                    "name": info["buddy_name"],
+                    "groups": info["shared_groups"],
+                    "shared_group_count": len(info["shared_groups"]),
+                    "avg_join_time_delta_days": avg_time_delta
+                }
+
+        return scored_buddies
+
+    async def _get_user_access_denials(
+        self,
+        user_id: str,
+        organization_id: str
+    ) -> List[Dict]:
+        """Get recent access denials for the user"""
+        cutoff_date = datetime.now() - timedelta(days=self.denial_lookback_days)
+
+        query = """
+            SELECT
+                "groupId" as group_id,
+                "documentId" as document_id,
+                "searchQuery" as search_query,
+                "denialReason" as denial_reason,
+                COUNT(*) as denial_count,
+                MAX("timestamp") as last_denial
+            FROM "AccessDenialLog"
+            WHERE "userId" = $1
+              AND "organizationId" = $2
+              AND "timestamp" > $3
+              AND "denialReason" = 'not_in_group'
+            GROUP BY "groupId", "documentId", "searchQuery", "denialReason"
+            ORDER BY denial_count DESC
+        """
+
+        async with database_service.pool.acquire() as conn:
+            rows = await conn.fetch(query, user_id, organization_id, cutoff_date)
+            return [dict(row) for row in rows]
+
+    def _calculate_frustration_score(self, denials: List[Dict]) -> float:
+        if not denials:
+            return 0.0
+
+        total_attempts = sum(d["denial_count"] for d in denials)
+        unique_queries = len(set(d["search_query"] for d in denials))
+
+        repetition_factor = total_attempts / max(unique_queries, 1)
+        return min(1.0, repetition_factor / 10.0)
+
+    async def _calculate_friends_of_friends_score(
+        self,
+        user_id: str,
+        group_id: str,
+        buddies: Dict[str, Dict],
+        organization_id: str
+    ) -> float:
+        if not buddies:
+            return 0.0
+
+        # Get members of the target group
+        query = """
+            SELECT gm."userId"
+            FROM "GroupMembership" gm
+            WHERE gm."groupId" = $1
+        """
+
+        async with database_service.pool.acquire() as conn:
+            rows = await conn.fetch(query, group_id)
+            group_members = {row["userId"] for row in rows}
+
+        # Count buddies of buddies in the target group
+        fof_connections = 0
+        for buddy_id in buddies.keys():
+            if buddy_id in group_members:
+                fof_connections += buddies[buddy_id]["score"]
+
+        # Normalize by number of buddies
+        return min(1.0, fof_connections / max(len(buddies), 1))
+
+    async def _get_user_groups(self, user_id: str, organization_id: str) -> List[Dict]:
+        """Get all groups the user is a member of"""
+        query = """
+            SELECT
+                g.id,
+                g.name,
+                gm."joinedAt" as joined_at,
+                gm."canUpload" as can_upload,
+                gm."canDelete" as can_delete
+            FROM "GroupMembership" gm
+            INNER JOIN "Group" g ON g.id = gm."groupId"
+            WHERE gm."userId" = $1
+              AND g."organizationId" = $2
+        """
+
+        async with database_service.pool.acquire() as conn:
+            rows = await conn.fetch(query, user_id, organization_id)
+            return [dict(row) for row in rows]
+
+    async def _get_all_groups(self, organization_id: str) -> List[Dict]:
+        """Get all groups in the organization"""
+        query = """
+            SELECT id, name, description
+            FROM "Group"
+            WHERE "organizationId" = $1
+        """
+
+        async with database_service.pool.acquire() as conn:
+            rows = await conn.fetch(query, organization_id)
+            return [dict(row) for row in rows]
+
+    def _generate_recommendation_reason(self, recommendation: Dict) -> str:
+        components = recommendation["components"]
+        reasons = []
+
+        if components["buddy_score"] > 0.2:
+            buddy_count = len(recommendation["buddies_in_group"])
+            reasons.append(f"{buddy_count} colleagues you frequently work with are in this group")
+
+        if components["denial_resolution_score"] > 0.05:
+            denials = recommendation["denials_resolved"]
+            reasons.append(f"would grant access to {denials} documents you've searched for")
+
+        if components["frustration_reduction"] > 0.05:
+            reasons.append("you've repeatedly tried to access content from this group")
+
+        if components["friends_of_friends_score"] > 0.2:
+            reasons.append("strongly connected through your network")
+
+        return " and ".join(reasons).capitalize() if reasons else "Recommended based on your collaboration patterns"
+
+
+# Create singleton instance
+heuristic_recommendation_service = HeuristicRecommendationService()

--- a/pythonService/app/services/heuristic_recommendation_service.py
+++ b/pythonService/app/services/heuristic_recommendation_service.py
@@ -247,6 +247,7 @@ class HeuristicRecommendationService:
         repetition_factor = total_attempts / max(unique_queries, 1)
         return min(1.0, repetition_factor / 10.0)
 
+    # TODO: Change name - just counts how many direct friends are in a group
     async def _calculate_friends_of_friends_score(
         self,
         user_id: str,

--- a/pythonService/app/services/heuristic_recommendation_service.py
+++ b/pythonService/app/services/heuristic_recommendation_service.py
@@ -41,7 +41,7 @@ class HeuristicRecommendationService:
             score_components = {
                 "buddy_score": 0.0,
                 "denial_resolution_score": 0.0,
-                "friends_of_friends_score": 0.0,
+                "friend_count_score": 0.0,
                 "frustration_reduction": 0.0
             }
 
@@ -64,16 +64,16 @@ class HeuristicRecommendationService:
                 frustration = self._calculate_frustration_score(denials_for_group)
                 score_components["frustration_reduction"] = frustration
 
-            fof_score = await self._calculate_friends_of_friends_score(
+            friend_count_score = await self._calculate_friend_count_score(
                 user_id, group["id"], buddies, organization_id
             )
-            score_components["friends_of_friends_score"] = fof_score
+            score_components["friend_count_score"] = friend_count_score
 
             final_score = (
                 score_components["buddy_score"] * 0.3 +
                 score_components["denial_resolution_score"] * 0.3 +
                 score_components["frustration_reduction"] * 0.2 +
-                score_components["friends_of_friends_score"] * 0.2
+                score_components["friend_count_score"] * 0.2
             )
 
             if final_score > 0:
@@ -247,8 +247,7 @@ class HeuristicRecommendationService:
         repetition_factor = total_attempts / max(unique_queries, 1)
         return min(1.0, repetition_factor / 10.0)
 
-    # TODO: Change name - just counts how many direct friends are in a group
-    async def _calculate_friends_of_friends_score(
+    async def _calculate_friend_count_score(
         self,
         user_id: str,
         group_id: str,
@@ -324,7 +323,7 @@ class HeuristicRecommendationService:
         if components["frustration_reduction"] > 0.05:
             reasons.append("you've repeatedly tried to access content from this group")
 
-        if components["friends_of_friends_score"] > 0.2:
+        if components["friend_count_score"] > 0.2:
             reasons.append("strongly connected through your network")
 
         return " and ".join(reasons).capitalize() if reasons else "Recommended based on your collaboration patterns"

--- a/pythonService/app/services/search_service.py
+++ b/pythonService/app/services/search_service.py
@@ -101,7 +101,6 @@ class SearchService:
             "indexes_used": {
                 "hnsw": org_indexes.hnsw_index is not None,
                 "bm25": False,  # TODO: Update when implemented
-                "inverted": False  # TODO: Update when implemented
             }
         }
 
@@ -145,10 +144,16 @@ class SearchService:
             logger.debug(f"Generated query embedding for '{query}' with {len(query_embedding)} dimensions")
             logger.debug(f"Searching HNSW index with filters: {filters}")
 
+            user_id = None
+            if filters and "permissions" in filters:
+                user_id = filters["permissions"].get("userId")
+
             search_results = hnsw_index.search(
                 query_vector=query_embedding,
                 k=k,
-                filters=filters
+                filters=filters,
+                search_query=query,
+                user_id=user_id
             )
 
             logger.debug(f"HNSW index returned {len(search_results)} raw candidates")

--- a/pythonService/tests/unit/test_heuristic_service_mock.py
+++ b/pythonService/tests/unit/test_heuristic_service_mock.py
@@ -1,0 +1,207 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from datetime import datetime, timedelta
+
+from app.services.heuristic_recommendation_service import HeuristicRecommendationService
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def mock_service():
+    return HeuristicRecommendationService()
+
+
+@pytest.fixture
+def mock_user_groups():
+    return [
+        {
+            "id": "group-1",
+            "name": "Engineering",
+            "joined_at": datetime.now() - timedelta(days=30),
+            "can_upload": True,
+            "can_delete": False
+        }
+    ]
+
+
+@pytest.fixture
+def mock_all_groups():
+    return [
+        {"id": "group-1", "name": "Engineering", "description": "Dev team"},
+        {"id": "group-2", "name": "Product", "description": "Product team"},
+        {"id": "group-3", "name": "Marketing", "description": "Marketing team"}
+    ]
+
+
+@pytest.fixture
+def mock_buddies():
+    return {
+        "user-buddy-1": {
+            "score": 0.8,
+            "name": "John Doe",
+            "groups": ["group-2"],
+            "shared_group_count": 1,
+            "avg_join_time_delta_days": 5
+        }
+    }
+
+
+@pytest.fixture
+def mock_denials():
+    return [
+        {
+            "group_id": "group-2",
+            "document_id": "doc-1",
+            "search_query": "product roadmap",
+            "denial_reason": "not_in_group",
+            "denial_count": 2,
+            "last_denial": datetime.now()
+        },
+        {
+            "group_id": "group-3",
+            "document_id": "doc-2",
+            "search_query": "marketing strategy",
+            "denial_reason": "not_in_group",
+            "denial_count": 1,
+            "last_denial": datetime.now()
+        }
+    ]
+
+
+class TestHeuristicRecommendationServiceMock:
+
+    @patch('app.services.heuristic_recommendation_service.database_service')
+    async def test_get_recommendations_basic(self, mock_db, mock_service, mock_user_groups,
+                                           mock_all_groups, mock_buddies, mock_denials):
+
+        # Mock database calls
+        mock_service._get_user_groups = AsyncMock(return_value=mock_user_groups)
+        mock_service._get_all_groups = AsyncMock(return_value=mock_all_groups)
+        mock_service._find_group_buddies = AsyncMock(return_value=mock_buddies)
+        mock_service._get_user_access_denials = AsyncMock(return_value=mock_denials)
+        mock_service._calculate_friend_count_score = AsyncMock(return_value=0.3)
+
+        recommendations = await mock_service.get_group_recommendations_for_user(
+            user_id="test-user",
+            organization_id="test-org",
+            top_k=3
+        )
+
+        # Should get recommendations for groups user is not in
+        assert len(recommendations) == 2
+
+        rec = recommendations[0]
+        assert "group_id" in rec
+        assert "group_name" in rec
+        assert "score" in rec
+        assert "reason" in rec
+        assert "details" in rec
+
+    @patch('app.services.heuristic_recommendation_service.database_service')
+    async def test_denial_resolution_scoring(self, mock_db, mock_service, mock_user_groups,
+                                           mock_all_groups, mock_denials):
+
+        mock_service._get_user_groups = AsyncMock(return_value=mock_user_groups)
+        mock_service._get_all_groups = AsyncMock(return_value=mock_all_groups)
+        mock_service._find_group_buddies = AsyncMock(return_value={})
+        mock_service._get_user_access_denials = AsyncMock(return_value=mock_denials)
+        mock_service._calculate_friend_count_score = AsyncMock(return_value=0.0)
+
+        recommendations = await mock_service.get_group_recommendations_for_user(
+            user_id="test-user",
+            organization_id="test-org",
+            top_k=3
+        )
+
+        group_scores = {rec["group_id"]: rec["score"] for rec in recommendations}
+        assert group_scores["group-2"] > group_scores["group-3"]
+
+    async def test_frustration_score_calculation(self, mock_service):
+
+        denials_repeated = [
+            {"denial_count": 3, "search_query": "same query"},
+            {"denial_count": 2, "search_query": "same query"}
+        ]
+        frustration_high = mock_service._calculate_frustration_score(denials_repeated)
+
+        denials_unique = [
+            {"denial_count": 1, "search_query": "query 1"},
+            {"denial_count": 1, "search_query": "query 2"}
+        ]
+        frustration_low = mock_service._calculate_frustration_score(denials_unique)
+
+        assert frustration_high > frustration_low
+
+    async def test_empty_denials_returns_no_recommendations(self, mock_service, mock_user_groups, mock_all_groups):
+
+        mock_service._get_user_groups = AsyncMock(return_value=mock_user_groups)
+        mock_service._get_all_groups = AsyncMock(return_value=mock_all_groups)
+        mock_service._find_group_buddies = AsyncMock(return_value={})
+        mock_service._get_user_access_denials = AsyncMock(return_value=[])
+        mock_service._calculate_friend_count_score = AsyncMock(return_value=0.0)
+
+        recommendations = await mock_service.get_group_recommendations_for_user(
+            user_id="test-user",
+            organization_id="test-org",
+            top_k=3
+        )
+
+        assert len(recommendations) == 0
+
+    async def test_recommendation_reason_generation(self, mock_service):
+        """Test that recommendation reasons are generated correctly"""
+
+        recommendation = {
+            "components": {
+                "buddy_score": 0.1,
+                "denial_resolution_score": 0.3,  # Above threshold
+                "friend_count_score": 0.1,
+                "frustration_reduction": 0.1
+            },
+            "buddies_in_group": [],
+            "denials_resolved": 3
+        }
+
+        reason = mock_service._generate_recommendation_reason(recommendation)
+        assert "access" in reason.lower() or "document" in reason.lower()
+
+    async def test_top_k_limiting(self, mock_service, mock_user_groups, mock_all_groups, mock_denials):
+
+        mock_service._get_user_groups = AsyncMock(return_value=mock_user_groups)
+        mock_service._get_all_groups = AsyncMock(return_value=mock_all_groups)
+        mock_service._find_group_buddies = AsyncMock(return_value={})
+        mock_service._get_user_access_denials = AsyncMock(return_value=mock_denials)
+        mock_service._calculate_friend_count_score = AsyncMock(return_value=0.0)
+
+        recommendations = await mock_service.get_group_recommendations_for_user(
+            user_id="test-user",
+            organization_id="test-org",
+            top_k=1
+        )
+
+        assert len(recommendations) <= 1
+
+    async def test_score_components_present(self, mock_service, mock_user_groups,
+                                          mock_all_groups, mock_buddies, mock_denials):
+
+        mock_service._get_user_groups = AsyncMock(return_value=mock_user_groups)
+        mock_service._get_all_groups = AsyncMock(return_value=mock_all_groups)
+        mock_service._find_group_buddies = AsyncMock(return_value=mock_buddies)
+        mock_service._get_user_access_denials = AsyncMock(return_value=mock_denials)
+        mock_service._calculate_friend_count_score = AsyncMock(return_value=0.2)
+
+        recommendations = await mock_service.get_group_recommendations_for_user(
+            user_id="test-user",
+            organization_id="test-org",
+            top_k=3
+        )
+
+        if recommendations:
+            score_breakdown = recommendations[0]["details"]["score_breakdown"]
+            expected_components = ["buddy_score", "denial_resolution_score",
+                                 "friend_count_score", "frustration_reduction"]
+
+            for component in expected_components:
+                assert component in score_breakdown
+                assert score_breakdown[component] >= 0


### PR DESCRIPTION
## Description
My TC2 was to create a recommendation algorithm for recommending which groups a user should be added to.

This PR implements a recommendation system that is based on four different heuristics.

The buddy score measures the strength of relationships with users who share group memberships.
It works by identifying "buddies", users who are in multiple shared groups with the target user and calculates the relationship strength based on their shared group ratio (number of shared groups/number of user's total groups), how close in time the users joined the shared groups, and whether the users have similar permissions in their shared groups.

The denial resolution score measures how many access denials would be resolved by joining a group.
It takes the last 30 days of AccessDenialLog entries, counts the unique denials where the denial reason was 'not_in_group'. Groups denials by target group to see which groups would unlock the most content.

The frustration reduction score measures the repeated failed attempts to access content. This is done by identifying repeated search queries that resulted in denials and giving higher scores for groups where users have made multiple attempts for the same content.

The friends count score just measures how many of the user's buddies are in a group.

A denial log also needed to be added to the database and logging was implemented inside of the search function.

## Milestones that this works towards
TC2 - Recommendation system

## Test Plan
<img width="1005" height="248" alt="Screenshot 2025-07-25 at 4 24 28 PM" src="https://github.com/user-attachments/assets/afea5f9d-8e76-4cfc-ba62-b6194a7dd6ba" />
